### PR TITLE
feat: Phase 2 - Navigation & UX Major Reform Implementation

### DIFF
--- a/app/(dashboard)/booking/new/page.tsx
+++ b/app/(dashboard)/booking/new/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useRouter } from "next/navigation"
-import { BookingWizard } from "@/components/booking/booking-wizard"
+import { SimpleBookingWizard } from "@/components/booking/simple/SimpleBookingWizard"
 import { createClient } from "@/lib/supabase/client"
 
 export default function NewBookingPage() {
@@ -71,11 +71,11 @@ export default function NewBookingPage() {
       <div className="mb-8">
         <h1 className="text-3xl font-bold">新規予約作成</h1>
         <p className="text-muted-foreground">
-          5ステップの簡単ウィザードで宿泊予約を作成します
+          3ステップの簡単ウィザードで宿泊予約を作成します
         </p>
       </div>
 
-      <BookingWizard onComplete={handleBookingComplete} />
+      <SimpleBookingWizard onComplete={handleBookingComplete} />
     </div>
   )
 }

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -13,7 +13,7 @@ const navigation = [
   { name: "ダッシュボード", href: "/dashboard", icon: Home },
   { name: "予約管理", href: "/booking", icon: BookOpen },
   { name: "カレンダー", href: "/calendar", icon: Calendar },
-  { name: "管理画面", href: "/admin", icon: Settings },
+  { name: "設定", href: "/settings", icon: Settings },
 ]
 
 export default function DashboardLayout({

--- a/app/(dashboard)/settings/customers/loading.tsx
+++ b/app/(dashboard)/settings/customers/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return null
+}

--- a/app/(dashboard)/settings/customers/page.tsx
+++ b/app/(dashboard)/settings/customers/page.tsx
@@ -1,0 +1,194 @@
+"use client"
+
+import { useState } from "react"
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Badge } from "@/components/ui/badge"
+import { Search, Eye, Mail, Phone } from "lucide-react"
+import { useBookingStore } from "@/store/booking-store"
+
+export default function CustomersAdminPage() {
+  const { customers, bookings } = useBookingStore()
+  const [searchTerm, setSearchTerm] = useState("")
+
+  const filteredCustomers = customers.filter(
+    (customer) =>
+      customer.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      customer.email.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      customer.phone.includes(searchTerm),
+  )
+
+  const getCustomerBookings = (customerId: string) => {
+    return bookings.filter((booking) => booking.customerId === customerId)
+  }
+
+  const getCustomerStats = (customerId: string) => {
+    const customerBookings = getCustomerBookings(customerId)
+    const totalSpent = customerBookings.reduce((sum, booking) => sum + booking.totalAmount, 0)
+    const completedBookings = customerBookings.filter((b) => b.status === "completed").length
+
+    return {
+      totalBookings: customerBookings.length,
+      completedBookings,
+      totalSpent,
+      lastBooking:
+        customerBookings.length > 0
+          ? new Date(Math.max(...customerBookings.map((b) => new Date(b.createdAt).getTime())))
+          : null,
+    }
+  }
+
+  return (
+    <div className="p-8">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold">顧客管理</h1>
+        <p className="text-muted-foreground">顧客情報の管理と履歴確認</p>
+      </div>
+
+      {/* 統計カード */}
+      <div className="grid gap-4 md:grid-cols-4 mb-8">
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">総顧客数</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{customers.length}</div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">リピーター</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              {customers.filter((c) => getCustomerBookings(c.id).length > 1).length}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">平均利用回数</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              {customers.length > 0 ? (bookings.length / customers.length).toFixed(1) : "0"}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">平均客単価</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              ¥
+              {bookings.length > 0
+                ? Math.round(bookings.reduce((sum, b) => sum + b.totalAmount, 0) / bookings.length).toLocaleString()
+                : "0"}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* 検索 */}
+      <Card className="mb-6">
+        <CardContent className="p-4">
+          <div className="relative">
+            <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
+            <Input
+              placeholder="顧客名、メール、電話番号で検索..."
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              className="pl-8"
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* 顧客一覧 */}
+      <Card>
+        <CardHeader>
+          <CardTitle>顧客一覧</CardTitle>
+          <CardDescription>{filteredCustomers.length}件の顧客が見つかりました</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>顧客名</TableHead>
+                <TableHead>連絡先</TableHead>
+                <TableHead>予約回数</TableHead>
+                <TableHead>総利用金額</TableHead>
+                <TableHead>最終利用日</TableHead>
+                <TableHead>ステータス</TableHead>
+                <TableHead>操作</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {filteredCustomers.map((customer) => {
+                const stats = getCustomerStats(customer.id)
+                return (
+                  <TableRow key={customer.id}>
+                    <TableCell>
+                      <div>
+                        <div className="font-medium">{customer.name}</div>
+                        <div className="text-sm text-muted-foreground">ID: {customer.id}</div>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <div className="space-y-1">
+                        <div className="flex items-center text-sm">
+                          <Mail className="mr-1 h-3 w-3" />
+                          {customer.email}
+                        </div>
+                        <div className="flex items-center text-sm">
+                          <Phone className="mr-1 h-3 w-3" />
+                          {customer.phone}
+                        </div>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <div className="text-center">
+                        <div className="font-medium">{stats.totalBookings}</div>
+                        <div className="text-xs text-muted-foreground">完了: {stats.completedBookings}</div>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <div className="font-medium">¥{stats.totalSpent.toLocaleString()}</div>
+                    </TableCell>
+                    <TableCell>
+                      {stats.lastBooking ? (
+                        <div className="text-sm">{stats.lastBooking.toLocaleDateString("ja-JP")}</div>
+                      ) : (
+                        <span className="text-muted-foreground">-</span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={stats.totalBookings > 1 ? "default" : "secondary"}>
+                        {stats.totalBookings > 1 ? "リピーター" : "新規"}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <Button variant="outline" size="sm" asChild>
+                        <Link href={`/admin/customers/${customer.id}`}>
+                          <Eye className="mr-1 h-3 w-3" />
+                          詳細
+                        </Link>
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                )
+              })}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/(dashboard)/settings/data/page.tsx
+++ b/app/(dashboard)/settings/data/page.tsx
@@ -1,0 +1,498 @@
+"use client"
+
+import { useState, useRef } from "react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Badge } from "@/components/ui/badge"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Checkbox } from "@/components/ui/checkbox"
+import { 
+  Upload, 
+  Download, 
+  Database, 
+  Trash2, 
+  FileDown, 
+  FileUp, 
+  AlertTriangle,
+  CheckCircle,
+  Settings
+} from "lucide-react"
+import { useRoomStore } from "@/store/room-store"
+import { useBookingStore } from "@/store/booking-store"
+import { usePricingStore } from "@/store/pricing-store"
+import { CSVExporter } from "@/lib/export/csv-exporter"
+import { CSVImporter } from "@/lib/export/csv-importer"
+
+export default function DataManagementPage() {
+  const { rooms, addRoom, deleteRoom, updateRoom } = useRoomStore()
+  const { bookings, customers } = useBookingStore()
+  const { rules } = usePricingStore()
+  
+  const [selectedRooms, setSelectedRooms] = useState<string[]>([])
+  const [selectedBookings, setSelectedBookings] = useState<string[]>([])
+  const [selectedRules, setSelectedRules] = useState<string[]>([])
+  const [isImporting, setIsImporting] = useState(false)
+  const [importResult, setImportResult] = useState<{ success: boolean; message: string; data?: any[] } | null>(null)
+  
+  const roomFileRef = useRef<HTMLInputElement>(null)
+  const optionFileRef = useRef<HTMLInputElement>(null)
+
+  // エクスポート機能
+  const handleExportRooms = () => {
+    CSVExporter.exportRooms(rooms)
+  }
+
+  const handleExportBookings = () => {
+    CSVExporter.exportBookings(bookings, rooms)
+  }
+
+  const handleExportOccupancy = () => {
+    const startDate = new Date()
+    startDate.setMonth(startDate.getMonth() - 1)
+    const endDate = new Date()
+    
+    CSVExporter.exportOccupancyReport(
+      startDate.toISOString().split('T')[0],
+      endDate.toISOString().split('T')[0],
+      rooms,
+      bookings
+    )
+  }
+
+  // テンプレートダウンロード
+  const handleDownloadRoomTemplate = () => {
+    CSVImporter.downloadRoomTemplate()
+  }
+
+  const handleDownloadOptionTemplate = () => {
+    CSVImporter.downloadOptionTemplate()
+  }
+
+  // インポート機能
+  const handleImportRooms = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    if (!file) return
+
+    setIsImporting(true)
+    try {
+      const roomData = await CSVImporter.importRooms(file)
+      
+      // データを実際にストアに追加
+      roomData.forEach(room => {
+        addRoom(room)
+      })
+      
+      setImportResult({
+        success: true,
+        message: `${roomData.length}件の部屋データを正常にインポートしました。`,
+        data: roomData
+      })
+    } catch (error) {
+      setImportResult({
+        success: false,
+        message: `インポートに失敗しました: ${error}`
+      })
+    } finally {
+      setIsImporting(false)
+      if (roomFileRef.current) {
+        roomFileRef.current.value = ''
+      }
+    }
+  }
+
+  // 一括削除機能
+  const handleBulkDeleteRooms = () => {
+    if (selectedRooms.length === 0) {
+      alert('削除する部屋を選択してください。')
+      return
+    }
+
+    if (confirm(`選択された${selectedRooms.length}件の部屋を削除しますか？`)) {
+      selectedRooms.forEach(roomId => {
+        deleteRoom(roomId)
+      })
+      setSelectedRooms([])
+    }
+  }
+
+  // 一括有効/無効切替
+  const handleBulkToggleRooms = (isActive: boolean) => {
+    if (selectedRooms.length === 0) {
+      alert('変更する部屋を選択してください。')
+      return
+    }
+
+    selectedRooms.forEach(roomId => {
+      const room = rooms.find(r => r.id === roomId)
+      if (room) {
+        updateRoom(roomId, { ...room, isActive })
+      }
+    })
+    setSelectedRooms([])
+  }
+
+  // データバックアップ
+  const handleBackupData = () => {
+    const backupData = {
+      rooms,
+      bookings,
+      customers,
+      pricingRules: rules,
+      exportDate: new Date().toISOString(),
+      version: "1.0"
+    }
+
+    const blob = new Blob([JSON.stringify(backupData, null, 2)], { 
+      type: "application/json;charset=utf-8;" 
+    })
+    const link = document.createElement("a")
+    
+    if (link.download !== undefined) {
+      const url = URL.createObjectURL(blob)
+      link.setAttribute("href", url)
+      link.setAttribute("download", `rebase369_backup_${new Date().toISOString().split('T')[0]}.json`)
+      link.style.visibility = "hidden"
+      document.body.appendChild(link)
+      link.click()
+      document.body.removeChild(link)
+    }
+  }
+
+  const handleSelectAllRooms = (checked: boolean) => {
+    if (checked) {
+      setSelectedRooms(rooms.map(room => room.id))
+    } else {
+      setSelectedRooms([])
+    }
+  }
+
+  const handleSelectRoom = (roomId: string, checked: boolean) => {
+    if (checked) {
+      setSelectedRooms(prev => [...prev, roomId])
+    } else {
+      setSelectedRooms(prev => prev.filter(id => id !== roomId))
+    }
+  }
+
+  return (
+    <div className="p-8">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold">データ管理</h1>
+        <p className="text-muted-foreground">データのインポート・エクスポート・バックアップ・一括操作</p>
+      </div>
+
+      {/* 統計概要 */}
+      <div className="grid gap-4 md:grid-cols-4 mb-8">
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">総部屋数</CardTitle>
+            <Database className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{rooms.length}</div>
+            <p className="text-xs text-muted-foreground">アクティブ: {rooms.filter(r => r.isActive).length}</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">総予約数</CardTitle>
+            <Database className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{bookings.length}</div>
+            <p className="text-xs text-muted-foreground">確定: {bookings.filter(b => b.status === 'confirmed').length}</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">顧客数</CardTitle>
+            <Database className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{customers.length}</div>
+            <p className="text-xs text-muted-foreground">登録済み顧客</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">料金ルール</CardTitle>
+            <Settings className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{rules.length}</div>
+            <p className="text-xs text-muted-foreground">アクティブ: {rules.filter(r => r.isActive).length}</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* インポート結果表示 */}
+      {importResult && (
+        <Alert className={`mb-6 ${importResult.success ? 'border-green-500' : 'border-red-500'}`}>
+          <div className="flex items-center">
+            {importResult.success ? (
+              <CheckCircle className="h-4 w-4 text-green-500" />
+            ) : (
+              <AlertTriangle className="h-4 w-4 text-red-500" />
+            )}
+            <AlertDescription className="ml-2">{importResult.message}</AlertDescription>
+          </div>
+        </Alert>
+      )}
+
+      <Tabs defaultValue="export" className="space-y-6">
+        <TabsList className="grid w-full grid-cols-4">
+          <TabsTrigger value="export">エクスポート</TabsTrigger>
+          <TabsTrigger value="import">インポート</TabsTrigger>
+          <TabsTrigger value="bulk">一括操作</TabsTrigger>
+          <TabsTrigger value="backup">バックアップ</TabsTrigger>
+        </TabsList>
+
+        {/* エクスポート */}
+        <TabsContent value="export">
+          <div className="grid gap-6 md:grid-cols-2">
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center">
+                  <Download className="mr-2 h-5 w-5" />
+                  データエクスポート
+                </CardTitle>
+                <CardDescription>各種データをCSV形式でエクスポート</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <Button onClick={handleExportRooms} className="w-full">
+                  <FileDown className="mr-2 h-4 w-4" />
+                  部屋データエクスポート
+                </Button>
+                <Button onClick={handleExportBookings} className="w-full">
+                  <FileDown className="mr-2 h-4 w-4" />
+                  予約データエクスポート
+                </Button>
+                <Button onClick={handleExportOccupancy} className="w-full">
+                  <FileDown className="mr-2 h-4 w-4" />
+                  稼働率レポートエクスポート
+                </Button>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center">
+                  <FileDown className="mr-2 h-5 w-5" />
+                  テンプレートダウンロード
+                </CardTitle>
+                <CardDescription>インポート用のCSVテンプレート</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <Button onClick={handleDownloadRoomTemplate} variant="outline" className="w-full">
+                  部屋データテンプレート
+                </Button>
+                <Button onClick={handleDownloadOptionTemplate} variant="outline" className="w-full">
+                  オプションデータテンプレート
+                </Button>
+              </CardContent>
+            </Card>
+          </div>
+        </TabsContent>
+
+        {/* インポート */}
+        <TabsContent value="import">
+          <div className="grid gap-6 md:grid-cols-2">
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center">
+                  <Upload className="mr-2 h-5 w-5" />
+                  部屋データインポート
+                </CardTitle>
+                <CardDescription>CSVファイルから部屋データを一括インポート</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="room-csv">CSVファイルを選択</Label>
+                  <Input
+                    id="room-csv"
+                    type="file"
+                    accept=".csv"
+                    ref={roomFileRef}
+                    onChange={handleImportRooms}
+                    disabled={isImporting}
+                  />
+                </div>
+                <div className="text-sm text-muted-foreground">
+                  <p>• CSVファイルはUTF-8エンコーディングで保存してください</p>
+                  <p>• 1行目はヘッダー行として扱われます</p>
+                  <p>• テンプレートファイルを参考にしてください</p>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center">
+                  <Upload className="mr-2 h-5 w-5" />
+                  オプションデータインポート
+                </CardTitle>
+                <CardDescription>CSVファイルからオプションデータを一括インポート</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="option-csv">CSVファイルを選択</Label>
+                  <Input
+                    id="option-csv"
+                    type="file"
+                    accept=".csv"
+                    ref={optionFileRef}
+                    disabled={isImporting}
+                  />
+                </div>
+                <div className="text-sm text-muted-foreground">
+                  <p>• 料金は数値のみで入力してください</p>
+                  <p>• カテゴリは meal/facility/equipment のいずれかです</p>
+                  <p>• 倍率は小数点で入力可能です（例：1.2）</p>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </TabsContent>
+
+        {/* 一括操作 */}
+        <TabsContent value="bulk">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center">
+                <Settings className="mr-2 h-5 w-5" />
+                一括操作
+              </CardTitle>
+              <CardDescription>選択したデータに対して一括操作を実行</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-6">
+                {/* 一括操作ボタン */}
+                <div className="flex gap-2 flex-wrap">
+                  <Button 
+                    onClick={() => handleBulkToggleRooms(true)}
+                    disabled={selectedRooms.length === 0}
+                    variant="outline"
+                  >
+                    選択部屋を有効化
+                  </Button>
+                  <Button 
+                    onClick={() => handleBulkToggleRooms(false)}
+                    disabled={selectedRooms.length === 0}
+                    variant="outline"
+                  >
+                    選択部屋を無効化
+                  </Button>
+                  <Button 
+                    onClick={handleBulkDeleteRooms}
+                    disabled={selectedRooms.length === 0}
+                    variant="destructive"
+                  >
+                    <Trash2 className="mr-2 h-4 w-4" />
+                    選択部屋を削除
+                  </Button>
+                </div>
+
+                {/* 部屋選択テーブル */}
+                <div>
+                  <div className="flex items-center justify-between mb-4">
+                    <h3 className="text-lg font-semibold">部屋選択 ({selectedRooms.length}/{rooms.length}件選択)</h3>
+                  </div>
+                  
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead className="w-12">
+                          <Checkbox
+                            checked={selectedRooms.length === rooms.length && rooms.length > 0}
+                            onCheckedChange={handleSelectAllRooms}
+                          />
+                        </TableHead>
+                        <TableHead>部屋名</TableHead>
+                        <TableHead>タイプ</TableHead>
+                        <TableHead>定員</TableHead>
+                        <TableHead>料金</TableHead>
+                        <TableHead>ステータス</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {rooms.map((room) => (
+                        <TableRow key={room.id}>
+                          <TableCell>
+                            <Checkbox
+                              checked={selectedRooms.includes(room.id)}
+                              onCheckedChange={(checked) => handleSelectRoom(room.id, checked as boolean)}
+                            />
+                          </TableCell>
+                          <TableCell className="font-medium">{room.name}</TableCell>
+                          <TableCell>{room.type}</TableCell>
+                          <TableCell>{room.capacity}名</TableCell>
+                          <TableCell>¥{room.basePrice?.toLocaleString()}</TableCell>
+                          <TableCell>
+                            <Badge variant={room.isActive ? "default" : "secondary"}>
+                              {room.isActive ? "アクティブ" : "非アクティブ"}
+                            </Badge>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        {/* バックアップ */}
+        <TabsContent value="backup">
+          <div className="grid gap-6 md:grid-cols-2">
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center">
+                  <Database className="mr-2 h-5 w-5" />
+                  データバックアップ
+                </CardTitle>
+                <CardDescription>システム全体のデータをバックアップ</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <Button onClick={handleBackupData} className="w-full">
+                  <Database className="mr-2 h-4 w-4" />
+                  完全バックアップ実行
+                </Button>
+                <div className="text-sm text-muted-foreground">
+                  <p>• 部屋データ、予約データ、顧客データ、料金ルールを含む</p>
+                  <p>• JSON形式でダウンロードされます</p>
+                  <p>• 定期的なバックアップを推奨します</p>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>バックアップ履歴</CardTitle>
+                <CardDescription>過去のバックアップ作成履歴</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="space-y-2">
+                  <div className="flex justify-between items-center p-2 border rounded">
+                    <span className="text-sm">今日 ({new Date().toLocaleDateString('ja-JP')})</span>
+                    <Badge variant="outline">手動</Badge>
+                  </div>
+                  <div className="text-sm text-muted-foreground">
+                    自動バックアップ機能は今後実装予定です
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}

--- a/app/(dashboard)/settings/layout.tsx
+++ b/app/(dashboard)/settings/layout.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import { useAuth } from "@/components/auth/auth-provider"
+import { ErrorBoundary } from "@/components/common/error-boundary"
+import { Loader2 } from "lucide-react"
+import { useRouter } from "next/navigation"
+import { useEffect } from "react"
+
+export default function SettingsLayout({ children }: { children: React.ReactNode }) {
+  const { user, loading } = useAuth()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (!loading && !user) {
+      router.push("/login")
+    }
+  }, [user, loading, router])
+
+  if (loading) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin" />
+        <span className="ml-2">認証確認中...</span>
+      </div>
+    )
+  }
+
+  if (!user) {
+    return null
+  }
+
+  return (
+    <ErrorBoundary>
+      {children || null}
+    </ErrorBoundary>
+  )
+}

--- a/app/(dashboard)/settings/options/page.tsx
+++ b/app/(dashboard)/settings/options/page.tsx
@@ -1,0 +1,625 @@
+"use client"
+
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Badge } from "@/components/ui/badge"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Plus, Edit, Trash2, Save, X } from "lucide-react"
+
+interface Option {
+  id: string
+  name: string
+  category: "meal" | "facility" | "equipment"
+  description: string
+  pricing: {
+    adult: number
+    student: number
+    child: number
+    preschool: number
+    infant: number
+  }
+  dayMultipliers: {
+    weekday: number
+    weekend: number
+  }
+  isActive: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+const sampleOptions: Option[] = [
+  {
+    id: "1",
+    name: "朝食",
+    category: "meal",
+    description: "和定食または洋定食をお選びいただけます",
+    pricing: {
+      adult: 700,
+      student: 700,
+      child: 700,
+      preschool: 700,
+      infant: 0,
+    },
+    dayMultipliers: {
+      weekday: 1.0,
+      weekend: 1.0,
+    },
+    isActive: true,
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+  },
+  {
+    id: "2",
+    name: "夕食",
+    category: "meal",
+    description: "地元の食材を使った会席料理",
+    pricing: {
+      adult: 1500,
+      student: 1000,
+      child: 800,
+      preschool: 0,
+      infant: 0,
+    },
+    dayMultipliers: {
+      weekday: 1.0,
+      weekend: 1.2,
+    },
+    isActive: true,
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+  },
+  {
+    id: "3",
+    name: "BBQ",
+    category: "meal",
+    description: "屋外バーベキュー（食材・機材込み）",
+    pricing: {
+      adult: 3000,
+      student: 2200,
+      child: 1500,
+      preschool: 0,
+      infant: 0,
+    },
+    dayMultipliers: {
+      weekday: 1.0,
+      weekend: 1.1,
+    },
+    isActive: true,
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+  },
+  {
+    id: "4",
+    name: "会議室",
+    category: "facility",
+    description: "プロジェクター付き会議室",
+    pricing: {
+      adult: 500,
+      student: 400,
+      child: 300,
+      preschool: 200,
+      infant: 0,
+    },
+    dayMultipliers: {
+      weekday: 1.0,
+      weekend: 1.5,
+    },
+    isActive: true,
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+  },
+  {
+    id: "5",
+    name: "体育館",
+    category: "facility",
+    description: "バスケットコート1面分の体育館",
+    pricing: {
+      adult: 500,
+      student: 500,
+      child: 500,
+      preschool: 500,
+      infant: 0,
+    },
+    dayMultipliers: {
+      weekday: 1.0,
+      weekend: 1.25,
+    },
+    isActive: true,
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+  },
+  {
+    id: "6",
+    name: "プロジェクター",
+    category: "equipment",
+    description: "HD対応プロジェクター",
+    pricing: {
+      adult: 3000,
+      student: 3000,
+      child: 3000,
+      preschool: 3000,
+      infant: 3000,
+    },
+    dayMultipliers: {
+      weekday: 1.0,
+      weekend: 1.0,
+    },
+    isActive: true,
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+  },
+]
+
+export default function OptionsAdminPage() {
+  const [options, setOptions] = useState<Option[]>(sampleOptions)
+  const [isEditing, setIsEditing] = useState<string | null>(null)
+  const [isAdding, setIsAdding] = useState(false)
+  const [editForm, setEditForm] = useState<Partial<Option>>({})
+  const [newOptionForm, setNewOptionForm] = useState<Partial<Option>>({
+    name: "",
+    category: "meal",
+    description: "",
+    pricing: {
+      adult: 0,
+      student: 0,
+      child: 0,
+      preschool: 0,
+      infant: 0,
+    },
+    dayMultipliers: {
+      weekday: 1.0,
+      weekend: 1.0,
+    },
+    isActive: true,
+  })
+
+  const categories = [
+    { value: "meal", label: "食事オプション" },
+    { value: "facility", label: "施設利用" },
+    { value: "equipment", label: "備品・機材" },
+  ]
+
+  const ageGroups = [
+    { key: "adult", label: "大人" },
+    { key: "student", label: "中高大学生" },
+    { key: "child", label: "小学生" },
+    { key: "preschool", label: "未就学児(3歳~)" },
+    { key: "infant", label: "乳幼児(0~2歳)" },
+  ]
+
+  const handleEdit = (option: Option) => {
+    setIsEditing(option.id)
+    setEditForm(option)
+  }
+
+  const handleSave = () => {
+    if (isEditing && editForm) {
+      setOptions((prev) =>
+        prev.map((option) =>
+          option.id === isEditing
+            ? { ...option, ...editForm, updatedAt: new Date().toISOString() }
+            : option,
+        ),
+      )
+      setIsEditing(null)
+      setEditForm({})
+    }
+  }
+
+  const handleCancel = () => {
+    setIsEditing(null)
+    setEditForm({})
+  }
+
+  const handleDelete = (optionId: string) => {
+    if (confirm("このオプションを削除してもよろしいですか？")) {
+      setOptions((prev) => prev.filter((option) => option.id !== optionId))
+    }
+  }
+
+  const handleAddOption = () => {
+    const newOption: Option = {
+      ...newOptionForm,
+      id: Math.random().toString(36).substr(2, 9),
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    } as Option
+
+    setOptions((prev) => [...prev, newOption])
+    setNewOptionForm({
+      name: "",
+      category: "meal",
+      description: "",
+      pricing: {
+        adult: 0,
+        student: 0,
+        child: 0,
+        preschool: 0,
+        infant: 0,
+      },
+      dayMultipliers: {
+        weekday: 1.0,
+        weekend: 1.0,
+      },
+      isActive: true,
+    })
+    setIsAdding(false)
+  }
+
+  const getCategoryLabel = (category: string) => {
+    return categories.find((c) => c.value === category)?.label || category
+  }
+
+  const filterOptionsByCategory = (category: string) => {
+    return options.filter((option) => option.category === category)
+  }
+
+  const OptionTable = ({ categoryOptions }: { categoryOptions: Option[] }) => (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>オプション名</TableHead>
+          <TableHead>説明</TableHead>
+          <TableHead>料金設定</TableHead>
+          <TableHead>曜日倍率</TableHead>
+          <TableHead>ステータス</TableHead>
+          <TableHead>操作</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {categoryOptions.map((option) => (
+          <TableRow key={option.id}>
+            <TableCell>
+              {isEditing === option.id ? (
+                <Input
+                  value={editForm.name}
+                  onChange={(e) => setEditForm({ ...editForm, name: e.target.value })}
+                />
+              ) : (
+                option.name
+              )}
+            </TableCell>
+            <TableCell>
+              {isEditing === option.id ? (
+                <Input
+                  value={editForm.description}
+                  onChange={(e) => setEditForm({ ...editForm, description: e.target.value })}
+                />
+              ) : (
+                option.description
+              )}
+            </TableCell>
+            <TableCell>
+              {isEditing === option.id ? (
+                <div className="space-y-2">
+                  {ageGroups.map((group) => (
+                    <div key={group.key} className="flex items-center gap-2">
+                      <Label className="w-20 text-xs">{group.label}:</Label>
+                      <Input
+                        type="number"
+                        value={editForm.pricing?.[group.key as keyof typeof editForm.pricing]}
+                        onChange={(e) =>
+                          setEditForm({
+                            ...editForm,
+                            pricing: {
+                              ...editForm.pricing!,
+                              [group.key]: Number.parseInt(e.target.value),
+                            },
+                          })
+                        }
+                        className="w-20"
+                      />
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="space-y-1">
+                  {ageGroups.map((group) => (
+                    <div key={group.key} className="text-xs">
+                      {group.label}: ¥{option.pricing[group.key as keyof typeof option.pricing]?.toLocaleString()}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </TableCell>
+            <TableCell>
+              {isEditing === option.id ? (
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    <Label className="w-12 text-xs">平日:</Label>
+                    <Input
+                      type="number"
+                      step="0.1"
+                      value={editForm.dayMultipliers?.weekday}
+                      onChange={(e) =>
+                        setEditForm({
+                          ...editForm,
+                          dayMultipliers: {
+                            ...editForm.dayMultipliers!,
+                            weekday: Number.parseFloat(e.target.value),
+                          },
+                        })
+                      }
+                      className="w-20"
+                    />
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Label className="w-12 text-xs">休日:</Label>
+                    <Input
+                      type="number"
+                      step="0.1"
+                      value={editForm.dayMultipliers?.weekend}
+                      onChange={(e) =>
+                        setEditForm({
+                          ...editForm,
+                          dayMultipliers: {
+                            ...editForm.dayMultipliers!,
+                            weekend: Number.parseFloat(e.target.value),
+                          },
+                        })
+                      }
+                      className="w-20"
+                    />
+                  </div>
+                </div>
+              ) : (
+                <div className="space-y-1">
+                  <div className="text-xs">平日: {option.dayMultipliers.weekday}x</div>
+                  <div className="text-xs">休日: {option.dayMultipliers.weekend}x</div>
+                </div>
+              )}
+            </TableCell>
+            <TableCell>
+              <Badge variant={option.isActive ? "default" : "secondary"}>
+                {option.isActive ? "アクティブ" : "非アクティブ"}
+              </Badge>
+            </TableCell>
+            <TableCell>
+              {isEditing === option.id ? (
+                <div className="flex gap-2">
+                  <Button size="sm" onClick={handleSave}>
+                    <Save className="h-4 w-4" />
+                  </Button>
+                  <Button size="sm" variant="outline" onClick={handleCancel}>
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
+              ) : (
+                <div className="flex gap-2">
+                  <Button size="sm" variant="outline" onClick={() => handleEdit(option)}>
+                    <Edit className="h-4 w-4" />
+                  </Button>
+                  <Button size="sm" variant="destructive" onClick={() => handleDelete(option.id)}>
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+              )}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  )
+
+  return (
+    <div className="p-8">
+      <div className="flex justify-between items-center mb-8">
+        <div>
+          <h1 className="text-3xl font-bold">オプション管理</h1>
+          <p className="text-muted-foreground">食事、施設利用、備品オプションの管理</p>
+        </div>
+        <Button onClick={() => setIsAdding(true)} disabled={isAdding}>
+          <Plus className="mr-2 h-4 w-4" />
+          新規オプション追加
+        </Button>
+      </div>
+
+      {/* 統計カード */}
+      <div className="grid gap-4 md:grid-cols-3 mb-8">
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">食事オプション</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{filterOptionsByCategory("meal").length}</div>
+            <p className="text-xs text-muted-foreground">朝食・夕食・BBQ</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">施設利用</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{filterOptionsByCategory("facility").length}</div>
+            <p className="text-xs text-muted-foreground">会議室・体育館</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">備品・機材</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{filterOptionsByCategory("equipment").length}</div>
+            <p className="text-xs text-muted-foreground">プロジェクター等</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* 新規オプション追加フォーム */}
+      {isAdding && (
+        <Card className="mb-6">
+          <CardHeader>
+            <CardTitle>新規オプション追加</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label>オプション名</Label>
+                <Input
+                  value={newOptionForm.name}
+                  onChange={(e) => setNewOptionForm({ ...newOptionForm, name: e.target.value })}
+                  placeholder="朝食"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>カテゴリ</Label>
+                <Select
+                  value={newOptionForm.category}
+                  onValueChange={(value: any) => setNewOptionForm({ ...newOptionForm, category: value })}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {categories.map((category) => (
+                      <SelectItem key={category.value} value={category.value}>
+                        {category.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label>説明</Label>
+              <Input
+                value={newOptionForm.description}
+                onChange={(e) => setNewOptionForm({ ...newOptionForm, description: e.target.value })}
+                placeholder="オプションの説明"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>年齢区分別料金設定</Label>
+              <div className="grid grid-cols-5 gap-4">
+                {ageGroups.map((group) => (
+                  <div key={group.key} className="space-y-1">
+                    <Label className="text-xs">{group.label}</Label>
+                    <Input
+                      type="number"
+                      value={newOptionForm.pricing?.[group.key as keyof typeof newOptionForm.pricing]}
+                      onChange={(e) =>
+                        setNewOptionForm({
+                          ...newOptionForm,
+                          pricing: {
+                            ...newOptionForm.pricing!,
+                            [group.key]: Number.parseInt(e.target.value),
+                          },
+                        })
+                      }
+                      placeholder="0"
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label>曜日別倍率</Label>
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-1">
+                  <Label className="text-xs">平日倍率</Label>
+                  <Input
+                    type="number"
+                    step="0.1"
+                    value={newOptionForm.dayMultipliers?.weekday}
+                    onChange={(e) =>
+                      setNewOptionForm({
+                        ...newOptionForm,
+                        dayMultipliers: {
+                          ...newOptionForm.dayMultipliers!,
+                          weekday: Number.parseFloat(e.target.value),
+                        },
+                      })
+                    }
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label className="text-xs">休日倍率</Label>
+                  <Input
+                    type="number"
+                    step="0.1"
+                    value={newOptionForm.dayMultipliers?.weekend}
+                    onChange={(e) =>
+                      setNewOptionForm({
+                        ...newOptionForm,
+                        dayMultipliers: {
+                          ...newOptionForm.dayMultipliers!,
+                          weekend: Number.parseFloat(e.target.value),
+                        },
+                      })
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+
+            <div className="flex gap-2">
+              <Button onClick={handleAddOption}>
+                <Save className="mr-2 h-4 w-4" />
+                保存
+              </Button>
+              <Button variant="outline" onClick={() => setIsAdding(false)}>
+                <X className="mr-2 h-4 w-4" />
+                キャンセル
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* オプション一覧 */}
+      <Tabs defaultValue="meal" className="space-y-6">
+        <TabsList className="grid w-full grid-cols-3">
+          <TabsTrigger value="meal">食事オプション</TabsTrigger>
+          <TabsTrigger value="facility">施設利用</TabsTrigger>
+          <TabsTrigger value="equipment">備品・機材</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="meal">
+          <Card>
+            <CardHeader>
+              <CardTitle>食事オプション管理</CardTitle>
+              <CardDescription>朝食・夕食・BBQなどの食事オプション</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <OptionTable categoryOptions={filterOptionsByCategory("meal")} />
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="facility">
+          <Card>
+            <CardHeader>
+              <CardTitle>施設利用管理</CardTitle>
+              <CardDescription>会議室・体育館などの施設利用オプション</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <OptionTable categoryOptions={filterOptionsByCategory("facility")} />
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="equipment">
+          <Card>
+            <CardHeader>
+              <CardTitle>備品・機材管理</CardTitle>
+              <CardDescription>プロジェクター・音響機器などの備品オプション</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <OptionTable categoryOptions={filterOptionsByCategory("equipment")} />
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}

--- a/app/(dashboard)/settings/page.tsx
+++ b/app/(dashboard)/settings/page.tsx
@@ -1,0 +1,303 @@
+"use client"
+
+import Link from "next/link"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { Separator } from "@/components/ui/separator"
+import { ErrorBoundary } from "@/components/common/error-boundary"
+import { ClientWrapper } from "@/components/common/client-wrapper"
+import { useHydration } from "@/hooks/use-hydration"
+import { useBookingStore } from "@/store/booking-store"
+import { useRoomStore } from "@/store/room-store"
+import { usePricingStore } from "@/store/pricing-store"
+import dynamic from "next/dynamic"
+
+// Dynamic imports for lucide-react icons to prevent SSR issues
+const Settings = dynamic(() => import("lucide-react").then(mod => ({ default: mod.Settings })), { ssr: false })
+const Users = dynamic(() => import("lucide-react").then(mod => ({ default: mod.Users })), { ssr: false })
+const Home = dynamic(() => import("lucide-react").then(mod => ({ default: mod.Home })), { ssr: false })
+const DollarSign = dynamic(() => import("lucide-react").then(mod => ({ default: mod.DollarSign })), { ssr: false })
+const BarChart3 = dynamic(() => import("lucide-react").then(mod => ({ default: mod.BarChart3 })), { ssr: false })
+const Database = dynamic(() => import("lucide-react").then(mod => ({ default: mod.Database })), { ssr: false })
+const Settings2 = dynamic(() => import("lucide-react").then(mod => ({ default: mod.Settings2 })), { ssr: false })
+
+export default function SettingsPage() {
+  const isHydrated = useHydration()
+  
+  // Safely get store data with error handling
+  let bookingStore, roomStore, pricingStore
+  try {
+    bookingStore = useBookingStore()
+    roomStore = useRoomStore()
+    pricingStore = usePricingStore()
+  } catch (error) {
+    console.error("Store initialization error:", error)
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <div className="text-center">
+          <p className="text-red-600">Store initialization failed. Please refresh the page.</p>
+        </div>
+      </div>
+    )
+  }
+
+  const { bookings = [], customers = [] } = bookingStore || {}
+  const { rooms = [] } = roomStore || {}
+  const { rules = [] } = pricingStore || {}
+
+  // Prevent rendering until hydration is complete to avoid React error #130
+  if (!isHydrated) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-gray-900"></div>
+          <p className="mt-4 text-gray-600">Loading...</p>
+        </div>
+      </div>
+    )
+  }
+
+  // Defensive programming: ensure all arrays are valid before operations
+  const safeBookings = Array.isArray(bookings) ? bookings : []
+  const safeCustomers = Array.isArray(customers) ? customers : []
+  const safeRooms = Array.isArray(rooms) ? rooms : []
+  const safeRules = Array.isArray(rules) ? rules : []
+
+  // Calculate stats with error handling
+  const stats = (() => {
+    try {
+      return {
+        totalBookings: safeBookings.length,
+        totalCustomers: safeCustomers.length,
+        totalRooms: safeRooms.length,
+        activePricingRules: safeRules.filter((r) => r && typeof r === 'object' && r.isActive === true).length,
+        totalRevenue: safeBookings.reduce((sum, b) => {
+          const amount = (b && typeof b === 'object' && typeof b.totalAmount === 'number') ? b.totalAmount : 0
+          return sum + amount
+        }, 0),
+      }
+    } catch (error) {
+      console.error("Stats calculation error:", error)
+      return {
+        totalBookings: 0,
+        totalCustomers: 0,
+        totalRooms: 0,
+        activePricingRules: 0,
+        totalRevenue: 0,
+      }
+    }
+  })()
+
+  return (
+    <ClientWrapper>
+      <ErrorBoundary>
+        <div className="p-8">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold">設定</h1>
+          <p className="text-muted-foreground">システムの設定とデータの管理</p>
+        </div>
+
+      {/* 統計概要 */}
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4 mb-8">
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">総予約数</CardTitle>
+            <BarChart3 className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{stats.totalBookings}</div>
+            <p className="text-xs text-muted-foreground">全期間合計</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">総売上</CardTitle>
+            <DollarSign className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">¥{stats.totalRevenue.toLocaleString()}</div>
+            <p className="text-xs text-muted-foreground">全期間合計</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">顧客・部屋</CardTitle>
+            <Users className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{stats.totalCustomers}・{stats.totalRooms}</div>
+            <p className="text-xs text-muted-foreground">顧客数・部屋数</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">料金ルール</CardTitle>
+            <Settings2 className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{stats.activePricingRules}</div>
+            <p className="text-xs text-muted-foreground">有効なルール</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* 設定メニュー */}
+      <div className="space-y-8">
+        {/* 基本設定 */}
+        <div>
+          <h2 className="text-xl font-semibold mb-4">基本設定</h2>
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            <Card className="hover:shadow-md transition-shadow">
+              <CardHeader>
+                <CardTitle className="flex items-center">
+                  <Home className="mr-2 h-5 w-5" />
+                  部屋管理
+                </CardTitle>
+                <CardDescription>部屋の追加、編集、削除</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="flex justify-between items-center mb-4">
+                  <span className="text-sm">登録部屋数</span>
+                  <Badge variant="outline">{safeRooms.length}件</Badge>
+                </div>
+                <Button asChild className="w-full">
+                  <Link href="/settings/rooms">管理画面を開く</Link>
+                </Button>
+              </CardContent>
+            </Card>
+
+            <Card className="hover:shadow-md transition-shadow">
+              <CardHeader>
+                <CardTitle className="flex items-center">
+                  <DollarSign className="mr-2 h-5 w-5" />
+                  料金設定
+                </CardTitle>
+                <CardDescription>料金ルールとシーズン料金</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="flex justify-between items-center mb-4">
+                  <span className="text-sm">アクティブルール</span>
+                  <Badge variant="outline">{stats.activePricingRules}件</Badge>
+                </div>
+                <Button asChild className="w-full">
+                  <Link href="/settings/pricing">管理画面を開く</Link>
+                </Button>
+              </CardContent>
+            </Card>
+
+            <Card className="hover:shadow-md transition-shadow">
+              <CardHeader>
+                <CardTitle className="flex items-center">
+                  <Settings2 className="mr-2 h-5 w-5" />
+                  オプション管理
+                </CardTitle>
+                <CardDescription>食事・施設・備品オプション</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="flex justify-between items-center mb-4">
+                  <span className="text-sm">登録オプション</span>
+                  <Badge variant="outline">6件</Badge>
+                </div>
+                <Button asChild className="w-full">
+                  <Link href="/settings/options">管理画面を開く</Link>
+                </Button>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+
+        <Separator />
+
+        {/* データ管理 */}
+        <div>
+          <h2 className="text-xl font-semibold mb-4">データ管理</h2>
+          <div className="grid gap-4 md:grid-cols-2">
+            <Card className="hover:shadow-md transition-shadow">
+              <CardHeader>
+                <CardTitle className="flex items-center">
+                  <Users className="mr-2 h-5 w-5" />
+                  顧客管理
+                </CardTitle>
+                <CardDescription>顧客情報と予約履歴</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="flex justify-between items-center mb-4">
+                  <span className="text-sm">登録顧客数</span>
+                  <Badge variant="outline">{safeCustomers.length}件</Badge>
+                </div>
+                <Button asChild className="w-full">
+                  <Link href="/settings/customers">管理画面を開く</Link>
+                </Button>
+              </CardContent>
+            </Card>
+
+            <Card className="hover:shadow-md transition-shadow">
+              <CardHeader>
+                <CardTitle className="flex items-center">
+                  <Database className="mr-2 h-5 w-5" />
+                  データ管理
+                </CardTitle>
+                <CardDescription>エクスポート・インポート・バックアップ</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <Button asChild className="w-full">
+                  <Link href="/settings/data">管理画面を開く</Link>
+                </Button>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+
+        <Separator />
+
+        {/* システム設定 */}
+        <div>
+          <h2 className="text-xl font-semibold mb-4">システム設定</h2>
+          <div className="grid gap-4 md:grid-cols-2">
+            <Card className="hover:shadow-md transition-shadow">
+              <CardHeader>
+                <CardTitle className="flex items-center">
+                  <BarChart3 className="mr-2 h-5 w-5" />
+                  売上レポート
+                </CardTitle>
+                <CardDescription>売上分析と稼働率レポート</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <Button asChild className="w-full">
+                  <Link href="/settings/reports">レポートを開く</Link>
+                </Button>
+              </CardContent>
+            </Card>
+
+            <Card className="hover:shadow-md transition-shadow">
+              <CardHeader>
+                <CardTitle className="flex items-center">
+                  <Settings className="mr-2 h-5 w-5" />
+                  システム設定
+                </CardTitle>
+                <CardDescription>基本設定と外部連携</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="space-y-2 mb-4">
+                  <div className="flex justify-between text-sm">
+                    <span>Supabase</span>
+                    <Badge variant="default" className="text-xs">接続済み</Badge>
+                  </div>
+                </div>
+                <Button asChild className="w-full">
+                  <Link href="/settings/system">設定を開く</Link>
+                </Button>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+        </div>
+        </div>
+      </ErrorBoundary>
+    </ClientWrapper>
+  )
+}

--- a/app/(dashboard)/settings/pricing/page.tsx
+++ b/app/(dashboard)/settings/pricing/page.tsx
@@ -1,0 +1,398 @@
+"use client"
+
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Badge } from "@/components/ui/badge"
+import { Plus, Edit, Trash2, Save, X, Calculator, Settings2 } from "lucide-react"
+import { usePricingStore } from "@/store/pricing-store"
+import { PricingMatrix } from "@/components/admin/pricing-matrix"
+import { EnhancedPricingMatrix } from "@/components/admin/enhanced-pricing-matrix"
+
+export default function PricingAdminPage() {
+  const { rules, addRule, updateRule, deleteRule } = usePricingStore()
+  const [isEditing, setIsEditing] = useState<string | null>(null)
+  const [isAdding, setIsAdding] = useState(false)
+  const [editForm, setEditForm] = useState<any>({})
+  const [activeTab, setActiveTab] = useState<string>("enhanced")
+  const [newRuleForm, setNewRuleForm] = useState({
+    name: "",
+    type: "seasonal" as const,
+    roomType: "",
+    startDate: "",
+    endDate: "",
+    dayOfWeek: [] as number[],
+    multiplier: 1.0,
+    fixedAmount: 0,
+    isActive: true,
+    priority: 1,
+  })
+
+  const ruleTypes = [
+    { value: "seasonal", label: "シーズン料金" },
+    { value: "weekday", label: "曜日料金" },
+    { value: "special", label: "特別料金" },
+    { value: "addon", label: "アドオン" },
+  ]
+
+  const weekDays = [
+    { value: 0, label: "日曜日" },
+    { value: 1, label: "月曜日" },
+    { value: 2, label: "火曜日" },
+    { value: 3, label: "水曜日" },
+    { value: 4, label: "木曜日" },
+    { value: 5, label: "金曜日" },
+    { value: 6, label: "土曜日" },
+  ]
+
+  const handleEdit = (rule: any) => {
+    setIsEditing(rule.id)
+    setEditForm(rule)
+  }
+
+  const handleSave = () => {
+    if (isEditing) {
+      updateRule(isEditing, editForm)
+      setIsEditing(null)
+      setEditForm({})
+    }
+  }
+
+  const handleCancel = () => {
+    setIsEditing(null)
+    setEditForm({})
+  }
+
+  const handleDelete = (ruleId: string) => {
+    if (confirm("この料金ルールを削除してもよろしいですか？")) {
+      deleteRule(ruleId)
+    }
+  }
+
+  const handleAddRule = () => {
+    const newRule = {
+      ...newRuleForm,
+      id: Math.random().toString(36).substr(2, 9),
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    }
+    addRule(newRule)
+    setNewRuleForm({
+      name: "",
+      type: "seasonal",
+      roomType: "",
+      startDate: "",
+      endDate: "",
+      dayOfWeek: [],
+      multiplier: 1.0,
+      fixedAmount: 0,
+      isActive: true,
+      priority: 1,
+    })
+    setIsAdding(false)
+  }
+
+  const toggleWeekDay = (day: number, isNew = false) => {
+    if (isNew) {
+      setNewRuleForm((prev) => ({
+        ...prev,
+        dayOfWeek: prev.dayOfWeek.includes(day) ? prev.dayOfWeek.filter((d) => d !== day) : [...prev.dayOfWeek, day],
+      }))
+    } else {
+      setEditForm((prev: any) => ({
+        ...prev,
+        dayOfWeek: prev.dayOfWeek?.includes(day)
+          ? prev.dayOfWeek.filter((d: number) => d !== day)
+          : [...(prev.dayOfWeek || []), day],
+      }))
+    }
+  }
+
+  const getRuleTypeLabel = (type: string) => {
+    return ruleTypes.find((t) => t.value === type)?.label || type
+  }
+
+  return (
+    <div className="p-8">
+      <div className="flex justify-between items-center mb-8">
+        <div>
+          <h1 className="text-3xl font-bold">料金設定</h1>
+          <p className="text-muted-foreground">料金ルールとシーズン料金の設定</p>
+        </div>
+        <div className="flex gap-2">
+          <Button 
+            variant={activeTab === "enhanced" ? "default" : "outline"} 
+            onClick={() => setActiveTab("enhanced")}
+          >
+            <Settings2 className="mr-2 h-4 w-4" />
+            料金マトリクス
+          </Button>
+          <Button 
+            variant={activeTab === "rules" ? "default" : "outline"} 
+            onClick={() => setActiveTab("rules")}
+          >
+            <Calculator className="mr-2 h-4 w-4" />
+            料金ルール管理
+          </Button>
+          <Button onClick={() => setIsAdding(true)} disabled={isAdding}>
+            <Plus className="mr-2 h-4 w-4" />
+            新規ルール追加
+          </Button>
+        </div>
+      </div>
+
+      {/* 新規ルール追加フォーム */}
+      {isAdding && (
+        <Card className="mb-6">
+          <CardHeader>
+            <CardTitle>新規料金ルール追加</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label>ルール名</Label>
+                <Input
+                  value={newRuleForm.name}
+                  onChange={(e) => setNewRuleForm({ ...newRuleForm, name: e.target.value })}
+                  placeholder="夏季料金"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>ルールタイプ</Label>
+                <Select
+                  value={newRuleForm.type}
+                  onValueChange={(value: any) => setNewRuleForm({ ...newRuleForm, type: value })}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {ruleTypes.map((type) => (
+                      <SelectItem key={type.value} value={type.value}>
+                        {type.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            {(newRuleForm.type === "seasonal" || newRuleForm.type === "special") && (
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label>開始日</Label>
+                  <Input
+                    type="date"
+                    value={newRuleForm.startDate}
+                    onChange={(e) => setNewRuleForm({ ...newRuleForm, startDate: e.target.value })}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label>終了日</Label>
+                  <Input
+                    type="date"
+                    value={newRuleForm.endDate}
+                    onChange={(e) => setNewRuleForm({ ...newRuleForm, endDate: e.target.value })}
+                  />
+                </div>
+              </div>
+            )}
+
+            {newRuleForm.type === "weekday" && (
+              <div className="space-y-2">
+                <Label>対象曜日</Label>
+                <div className="grid grid-cols-7 gap-2">
+                  {weekDays.map((day) => (
+                    <Button
+                      key={day.value}
+                      variant={newRuleForm.dayOfWeek.includes(day.value) ? "default" : "outline"}
+                      size="sm"
+                      onClick={() => toggleWeekDay(day.value, true)}
+                    >
+                      {day.label.charAt(0)}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <div className="grid grid-cols-3 gap-4">
+              <div className="space-y-2">
+                <Label>優先度</Label>
+                <Input
+                  type="number"
+                  value={newRuleForm.priority}
+                  onChange={(e) => setNewRuleForm({ ...newRuleForm, priority: Number.parseInt(e.target.value) })}
+                />
+              </div>
+              {newRuleForm.type !== "addon" ? (
+                <div className="space-y-2">
+                  <Label>倍率</Label>
+                  <Input
+                    type="number"
+                    step="0.1"
+                    value={newRuleForm.multiplier}
+                    onChange={(e) => setNewRuleForm({ ...newRuleForm, multiplier: Number.parseFloat(e.target.value) })}
+                  />
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  <Label>固定金額</Label>
+                  <Input
+                    type="number"
+                    value={newRuleForm.fixedAmount}
+                    onChange={(e) => setNewRuleForm({ ...newRuleForm, fixedAmount: Number.parseInt(e.target.value) })}
+                  />
+                </div>
+              )}
+            </div>
+
+            <div className="flex gap-2">
+              <Button onClick={handleAddRule}>
+                <Save className="mr-2 h-4 w-4" />
+                保存
+              </Button>
+              <Button variant="outline" onClick={() => setIsAdding(false)}>
+                <X className="mr-2 h-4 w-4" />
+                キャンセル
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* 料金マトリクス */}
+      {activeTab === "enhanced" && (
+        <EnhancedPricingMatrix />
+      )}
+
+      {/* 料金ルール一覧 */}
+      {activeTab === "rules" && (
+      <Card>
+        <CardHeader>
+          <CardTitle>料金ルール一覧</CardTitle>
+          <CardDescription>{rules.length}件のルールが登録されています</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>ルール名</TableHead>
+                <TableHead>タイプ</TableHead>
+                <TableHead>期間/曜日</TableHead>
+                <TableHead>倍率/金額</TableHead>
+                <TableHead>優先度</TableHead>
+                <TableHead>ステータス</TableHead>
+                <TableHead>操作</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rules
+                .sort((a, b) => a.priority - b.priority)
+                .map((rule) => (
+                  <TableRow key={rule.id}>
+                    <TableCell>
+                      {isEditing === rule.id ? (
+                        <Input
+                          value={editForm.name}
+                          onChange={(e) => setEditForm({ ...editForm, name: e.target.value })}
+                        />
+                      ) : (
+                        rule.name
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant="outline">{getRuleTypeLabel(rule.type)}</Badge>
+                    </TableCell>
+                    <TableCell>
+                      {rule.type === "seasonal" || rule.type === "special" ? (
+                        <span className="text-sm">
+                          {rule.startDate} ～ {rule.endDate}
+                        </span>
+                      ) : rule.type === "weekday" ? (
+                        <div className="flex gap-1">
+                          {rule.dayOfWeek?.map((day) => (
+                            <Badge key={day} variant="secondary" className="text-xs">
+                              {weekDays.find((d) => d.value === day)?.label.charAt(0)}
+                            </Badge>
+                          ))}
+                        </div>
+                      ) : (
+                        "-"
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {isEditing === rule.id ? (
+                        rule.type === "addon" ? (
+                          <Input
+                            type="number"
+                            value={editForm.fixedAmount}
+                            onChange={(e) => setEditForm({ ...editForm, fixedAmount: Number.parseInt(e.target.value) })}
+                          />
+                        ) : (
+                          <Input
+                            type="number"
+                            step="0.1"
+                            value={editForm.multiplier}
+                            onChange={(e) =>
+                              setEditForm({ ...editForm, multiplier: Number.parseFloat(e.target.value) })
+                            }
+                          />
+                        )
+                      ) : rule.type === "addon" ? (
+                        `¥${rule.fixedAmount?.toLocaleString()}`
+                      ) : (
+                        `${rule.multiplier}x`
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {isEditing === rule.id ? (
+                        <Input
+                          type="number"
+                          value={editForm.priority}
+                          onChange={(e) => setEditForm({ ...editForm, priority: Number.parseInt(e.target.value) })}
+                        />
+                      ) : (
+                        rule.priority
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={rule.isActive ? "default" : "secondary"}>
+                        {rule.isActive ? "アクティブ" : "非アクティブ"}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      {isEditing === rule.id ? (
+                        <div className="flex gap-2">
+                          <Button size="sm" onClick={handleSave}>
+                            <Save className="h-4 w-4" />
+                          </Button>
+                          <Button size="sm" variant="outline" onClick={handleCancel}>
+                            <X className="h-4 w-4" />
+                          </Button>
+                        </div>
+                      ) : (
+                        <div className="flex gap-2">
+                          <Button size="sm" variant="outline" onClick={() => handleEdit(rule)}>
+                            <Edit className="h-4 w-4" />
+                          </Button>
+                          <Button size="sm" variant="destructive" onClick={() => handleDelete(rule.id)}>
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        </div>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+      )}
+    </div>
+  )
+}

--- a/app/(dashboard)/settings/reports/page.tsx
+++ b/app/(dashboard)/settings/reports/page.tsx
@@ -1,0 +1,356 @@
+"use client"
+
+import { useState } from "react"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Badge } from "@/components/ui/badge"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { TrendingUp, Calendar, DollarSign, Home } from "lucide-react"
+import { useBookingStore } from "@/store/booking-store"
+import { useRoomStore } from "@/store/room-store"
+
+export default function ReportsPage() {
+  const { bookings, customers } = useBookingStore()
+  const { rooms } = useRoomStore()
+  const [selectedPeriod, setSelectedPeriod] = useState("month")
+
+  // 売上統計の計算
+  const calculateRevenue = () => {
+    const completedBookings = bookings.filter((b) => b.status === "completed")
+    const totalRevenue = completedBookings.reduce((sum, b) => sum + b.totalAmount, 0)
+    const averageBookingValue = completedBookings.length > 0 ? totalRevenue / completedBookings.length : 0
+
+    return {
+      totalRevenue,
+      completedBookings: completedBookings.length,
+      averageBookingValue,
+      pendingRevenue: bookings.filter((b) => b.status === "pending").reduce((sum, b) => sum + b.totalAmount, 0),
+    }
+  }
+
+  // 稼働率の計算
+  const calculateOccupancy = () => {
+    const today = new Date()
+    const currentMonth = today.getMonth()
+    const currentYear = today.getFullYear()
+    const daysInMonth = new Date(currentYear, currentMonth + 1, 0).getDate()
+
+    let occupiedRoomDays = 0
+    const totalRoomDays = rooms.length * daysInMonth
+
+    bookings.forEach((booking) => {
+      const checkIn = new Date(booking.checkIn)
+      const checkOut = new Date(booking.checkOut)
+
+      if (checkIn.getMonth() === currentMonth && checkIn.getFullYear() === currentYear) {
+        const nights = Math.ceil((checkOut.getTime() - checkIn.getTime()) / (1000 * 60 * 60 * 24))
+        occupiedRoomDays += nights
+      }
+    })
+
+    return totalRoomDays > 0 ? (occupiedRoomDays / totalRoomDays) * 100 : 0
+  }
+
+  // 部屋別統計
+  const getRoomStats = () => {
+    return rooms
+      .map((room) => {
+        const roomBookings = bookings.filter((b) => b.roomId === room.id)
+        const revenue = roomBookings.reduce((sum, b) => sum + b.totalAmount, 0)
+        const bookingCount = roomBookings.length
+
+        return {
+          room,
+          bookingCount,
+          revenue,
+          averageRate: bookingCount > 0 ? revenue / bookingCount : 0,
+        }
+      })
+      .sort((a, b) => b.revenue - a.revenue)
+  }
+
+  // 月別統計
+  const getMonthlyStats = () => {
+    const monthlyData: { [key: string]: { bookings: number; revenue: number } } = {}
+
+    bookings.forEach((booking) => {
+      const date = new Date(booking.createdAt)
+      const monthKey = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`
+
+      if (!monthlyData[monthKey]) {
+        monthlyData[monthKey] = { bookings: 0, revenue: 0 }
+      }
+
+      monthlyData[monthKey].bookings += 1
+      monthlyData[monthKey].revenue += booking.totalAmount
+    })
+
+    return Object.entries(monthlyData)
+      .sort(([a], [b]) => b.localeCompare(a))
+      .slice(0, 12)
+  }
+
+  const revenue = calculateRevenue()
+  const occupancyRate = calculateOccupancy()
+  const roomStats = getRoomStats()
+  const monthlyStats = getMonthlyStats()
+
+  return (
+    <div className="p-8">
+      <div className="flex justify-between items-center mb-8">
+        <div>
+          <h1 className="text-3xl font-bold">レポート</h1>
+          <p className="text-muted-foreground">売上レポートと分析データ</p>
+        </div>
+        <Select value={selectedPeriod} onValueChange={setSelectedPeriod}>
+          <SelectTrigger className="w-[180px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="week">今週</SelectItem>
+            <SelectItem value="month">今月</SelectItem>
+            <SelectItem value="quarter">四半期</SelectItem>
+            <SelectItem value="year">今年</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* 主要指標 */}
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4 mb-8">
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">総売上</CardTitle>
+            <DollarSign className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">¥{revenue.totalRevenue.toLocaleString()}</div>
+            <p className="text-xs text-muted-foreground">完了済み予約: {revenue.completedBookings}件</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">平均客単価</CardTitle>
+            <TrendingUp className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">¥{Math.round(revenue.averageBookingValue).toLocaleString()}</div>
+            <p className="text-xs text-muted-foreground">1予約あたりの平均金額</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">稼働率</CardTitle>
+            <Home className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{occupancyRate.toFixed(1)}%</div>
+            <p className="text-xs text-muted-foreground">今月の部屋稼働率</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">保留中売上</CardTitle>
+            <Calendar className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">¥{revenue.pendingRevenue.toLocaleString()}</div>
+            <p className="text-xs text-muted-foreground">確定待ちの売上</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Tabs defaultValue="rooms" className="space-y-6">
+        <TabsList>
+          <TabsTrigger value="rooms">部屋別分析</TabsTrigger>
+          <TabsTrigger value="monthly">月別推移</TabsTrigger>
+          <TabsTrigger value="customers">顧客分析</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="rooms" className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>部屋別売上ランキング</CardTitle>
+              <CardDescription>各部屋の予約数と売上実績</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>部屋名</TableHead>
+                    <TableHead>タイプ</TableHead>
+                    <TableHead>予約数</TableHead>
+                    <TableHead>売上</TableHead>
+                    <TableHead>平均単価</TableHead>
+                    <TableHead>稼働率</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {roomStats.map((stat, index) => (
+                    <TableRow key={stat.room.id}>
+                      <TableCell>
+                        <div className="flex items-center gap-2">
+                          <Badge variant="outline">#{index + 1}</Badge>
+                          {stat.room.name}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant="secondary">{stat.room.type}</Badge>
+                      </TableCell>
+                      <TableCell>{stat.bookingCount}件</TableCell>
+                      <TableCell>¥{stat.revenue.toLocaleString()}</TableCell>
+                      <TableCell>¥{Math.round(stat.averageRate).toLocaleString()}</TableCell>
+                      <TableCell>
+                        <div className="flex items-center gap-2">
+                          <div className="w-16 bg-gray-200 rounded-full h-2">
+                            <div
+                              className="bg-blue-600 h-2 rounded-full"
+                              style={{
+                                width: `${Math.min((stat.bookingCount / Math.max(...roomStats.map((s) => s.bookingCount))) * 100, 100)}%`,
+                              }}
+                            ></div>
+                          </div>
+                          <span className="text-sm">
+                            {((stat.bookingCount / Math.max(...roomStats.map((s) => s.bookingCount))) * 100).toFixed(0)}
+                            %
+                          </span>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="monthly" className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>月別売上推移</CardTitle>
+              <CardDescription>過去12ヶ月の予約数と売上の推移</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>年月</TableHead>
+                    <TableHead>予約数</TableHead>
+                    <TableHead>売上</TableHead>
+                    <TableHead>平均単価</TableHead>
+                    <TableHead>前月比</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {monthlyStats.map(([month, data], index) => {
+                    const prevData = monthlyStats[index + 1]?.[1]
+                    const growthRate = prevData ? ((data.revenue - prevData.revenue) / prevData.revenue) * 100 : 0
+
+                    return (
+                      <TableRow key={month}>
+                        <TableCell className="font-medium">{month}</TableCell>
+                        <TableCell>{data.bookings}件</TableCell>
+                        <TableCell>¥{data.revenue.toLocaleString()}</TableCell>
+                        <TableCell>
+                          ¥{data.bookings > 0 ? Math.round(data.revenue / data.bookings).toLocaleString() : "0"}
+                        </TableCell>
+                        <TableCell>
+                          {prevData ? (
+                            <Badge variant={growthRate >= 0 ? "default" : "destructive"}>
+                              {growthRate >= 0 ? "+" : ""}
+                              {growthRate.toFixed(1)}%
+                            </Badge>
+                          ) : (
+                            "-"
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    )
+                  })}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="customers" className="space-y-6">
+          <div className="grid gap-4 md:grid-cols-3">
+            <Card>
+              <CardHeader>
+                <CardTitle>顧客統計</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="flex justify-between">
+                  <span>総顧客数:</span>
+                  <span className="font-bold">{customers.length}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>リピーター:</span>
+                  <span className="font-bold">
+                    {customers.filter((c) => bookings.filter((b) => b.customerId === c.id).length > 1).length}
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span>リピート率:</span>
+                  <span className="font-bold">
+                    {customers.length > 0
+                      ? (
+                          (customers.filter((c) => bookings.filter((b) => b.customerId === c.id).length > 1).length /
+                            customers.length) *
+                          100
+                        ).toFixed(1)
+                      : "0"}
+                    %
+                  </span>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>予約パターン</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="flex justify-between">
+                  <span>平均予約間隔:</span>
+                  <span className="font-bold">45日</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>平均滞在日数:</span>
+                  <span className="font-bold">2.3日</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>平均宿泊人数:</span>
+                  <span className="font-bold">2.1名</span>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>顧客価値</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="flex justify-between">
+                  <span>LTV平均:</span>
+                  <span className="font-bold">¥85,000</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>最高LTV:</span>
+                  <span className="font-bold">¥250,000</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>新規獲得コスト:</span>
+                  <span className="font-bold">¥12,000</span>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}

--- a/app/(dashboard)/settings/rooms/page.tsx
+++ b/app/(dashboard)/settings/rooms/page.tsx
@@ -1,0 +1,400 @@
+"use client"
+
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Badge } from "@/components/ui/badge"
+import { Plus, Edit, Trash2, Save, X } from "lucide-react"
+import { useRoomStore } from "@/store/room-store"
+
+export default function RoomsAdminPage() {
+  const { rooms, addRoom, updateRoom, deleteRoom } = useRoomStore()
+  const [isEditing, setIsEditing] = useState<string | null>(null)
+  const [isAdding, setIsAdding] = useState(false)
+  const [editForm, setEditForm] = useState<any>({})
+  const [floorFilter, setFloorFilter] = useState<string>("all")
+  const [newRoomForm, setNewRoomForm] = useState({
+    name: "",
+    type: "double" as const,
+    capacity: 2,
+    basePrice: 15000,
+    amenities: [] as string[],
+    description: "",
+    isActive: true,
+  })
+
+  const roomTypes = [
+    { value: "single", label: "シングル" },
+    { value: "double", label: "ダブル" },
+    { value: "suite", label: "スイート" },
+    { value: "family", label: "ファミリー" },
+  ]
+
+  const amenityOptions = [
+    "WiFi",
+    "エアコン",
+    "テレビ",
+    "バスルーム",
+    "キッチン",
+    "バルコニー",
+    "冷蔵庫",
+    "電子レンジ",
+    "洗濯機",
+    "駐車場",
+  ]
+
+  const handleEdit = (room: any) => {
+    setIsEditing(room.id)
+    setEditForm(room)
+  }
+
+  const handleSave = () => {
+    if (isEditing) {
+      updateRoom(isEditing, editForm)
+      setIsEditing(null)
+      setEditForm({})
+    }
+  }
+
+  const handleCancel = () => {
+    setIsEditing(null)
+    setEditForm({})
+  }
+
+  const handleDelete = (roomId: string) => {
+    if (confirm("この部屋を削除してもよろしいですか？")) {
+      deleteRoom(roomId)
+    }
+  }
+
+  const handleAddRoom = () => {
+    const newRoom = {
+      ...newRoomForm,
+      id: Math.random().toString(36).substr(2, 9),
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    }
+    addRoom(newRoom)
+    setNewRoomForm({
+      name: "",
+      type: "double",
+      capacity: 2,
+      basePrice: 15000,
+      amenities: [],
+      description: "",
+      isActive: true,
+    })
+    setIsAdding(false)
+  }
+
+  const toggleAmenity = (amenity: string, isNew = false) => {
+    if (isNew) {
+      setNewRoomForm((prev) => ({
+        ...prev,
+        amenities: prev.amenities.includes(amenity)
+          ? prev.amenities.filter((a) => a !== amenity)
+          : [...prev.amenities, amenity],
+      }))
+    } else {
+      setEditForm((prev: any) => ({
+        ...prev,
+        amenities: prev.amenities.includes(amenity)
+          ? prev.amenities.filter((a: string) => a !== amenity)
+          : [...prev.amenities, amenity],
+      }))
+    }
+  }
+
+  const filteredRooms = rooms.filter((room) => {
+    if (floorFilter === "all") return true
+    return room.type === floorFilter || room.name.includes(floorFilter)
+  })
+
+  return (
+    <div className="p-8">
+      <div className="flex justify-between items-center mb-8">
+        <div>
+          <h1 className="text-3xl font-bold">部屋管理</h1>
+          <p className="text-muted-foreground">部屋の追加、編集、削除を行います</p>
+        </div>
+        <div className="flex gap-4 items-center">
+          <div className="space-y-2">
+            <Label>フロア別表示</Label>
+            <Select value={floorFilter} onValueChange={setFloorFilter}>
+              <SelectTrigger className="w-[180px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">全フロア</SelectItem>
+                <SelectItem value="2F">2F</SelectItem>
+                <SelectItem value="3F">3F</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <Button onClick={() => setIsAdding(true)} disabled={isAdding}>
+            <Plus className="mr-2 h-4 w-4" />
+            新規部屋追加
+          </Button>
+        </div>
+      </div>
+
+      {/* 新規部屋追加フォーム */}
+      {isAdding && (
+        <Card className="mb-6">
+          <CardHeader>
+            <CardTitle>新規部屋追加</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label>部屋名</Label>
+                <Input
+                  value={newRoomForm.name}
+                  onChange={(e) => setNewRoomForm({ ...newRoomForm, name: e.target.value })}
+                  placeholder="スタンダードルーム A"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>部屋タイプ</Label>
+                <Select
+                  value={newRoomForm.type}
+                  onValueChange={(value: any) => setNewRoomForm({ ...newRoomForm, type: value })}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {roomTypes.map((type) => (
+                      <SelectItem key={type.value} value={type.value}>
+                        {type.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label>定員</Label>
+                <Select
+                  value={newRoomForm.capacity.toString()}
+                  onValueChange={(value) => setNewRoomForm({ ...newRoomForm, capacity: Number.parseInt(value) })}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {[1, 2, 3, 4, 5, 6].map((num) => (
+                      <SelectItem key={num} value={num.toString()}>
+                        {num}名
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label>基本料金</Label>
+                <Input
+                  type="number"
+                  value={newRoomForm.basePrice}
+                  onChange={(e) => setNewRoomForm({ ...newRoomForm, basePrice: Number.parseInt(e.target.value) })}
+                />
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label>設備・アメニティ</Label>
+              <div className="grid grid-cols-5 gap-2">
+                {amenityOptions.map((amenity) => (
+                  <Button
+                    key={amenity}
+                    variant={newRoomForm.amenities.includes(amenity) ? "default" : "outline"}
+                    size="sm"
+                    onClick={() => toggleAmenity(amenity, true)}
+                  >
+                    {amenity}
+                  </Button>
+                ))}
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label>説明</Label>
+              <Input
+                value={newRoomForm.description}
+                onChange={(e) => setNewRoomForm({ ...newRoomForm, description: e.target.value })}
+                placeholder="部屋の説明"
+              />
+            </div>
+
+            <div className="flex gap-2">
+              <Button onClick={handleAddRoom}>
+                <Save className="mr-2 h-4 w-4" />
+                保存
+              </Button>
+              <Button variant="outline" onClick={() => setIsAdding(false)}>
+                <X className="mr-2 h-4 w-4" />
+                キャンセル
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* 部屋一覧 */}
+      <Card>
+        <CardHeader>
+          <CardTitle>部屋一覧</CardTitle>
+          <CardDescription>{rooms.length}件の部屋が登録されています</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>部屋名</TableHead>
+                <TableHead>タイプ</TableHead>
+                <TableHead>定員</TableHead>
+                <TableHead>基本料金</TableHead>
+                <TableHead>設備</TableHead>
+                <TableHead>ステータス</TableHead>
+                <TableHead>操作</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {filteredRooms.map((room) => (
+                <TableRow key={room.id}>
+                  <TableCell>
+                    {isEditing === room.id ? (
+                      <Input
+                        value={editForm.name}
+                        onChange={(e) => setEditForm({ ...editForm, name: e.target.value })}
+                      />
+                    ) : (
+                      room.name
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    {isEditing === room.id ? (
+                      <Select
+                        value={editForm.type}
+                        onValueChange={(value) => setEditForm({ ...editForm, type: value })}
+                      >
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {roomTypes.map((type) => (
+                            <SelectItem key={type.value} value={type.value}>
+                              {type.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    ) : (
+                      roomTypes.find((t) => t.value === room.type)?.label
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    {isEditing === room.id ? (
+                      <Select
+                        value={editForm.capacity.toString()}
+                        onValueChange={(value) => setEditForm({ ...editForm, capacity: Number.parseInt(value) })}
+                      >
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {[1, 2, 3, 4, 5, 6].map((num) => (
+                            <SelectItem key={num} value={num.toString()}>
+                              {num}名
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    ) : (
+                      `${room.capacity}名`
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    {isEditing === room.id ? (
+                      <Input
+                        type="number"
+                        value={editForm.basePrice}
+                        onChange={(e) => setEditForm({ ...editForm, basePrice: Number.parseInt(e.target.value) })}
+                      />
+                    ) : (
+                      `¥${room.basePrice.toLocaleString()}`
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    {isEditing === room.id ? (
+                      <div className="space-y-2">
+                        <div className="grid grid-cols-3 gap-1">
+                          {amenityOptions.map((amenity) => (
+                            <Button
+                              key={amenity}
+                              variant={editForm.amenities?.includes(amenity) ? "default" : "outline"}
+                              size="sm"
+                              onClick={() => toggleAmenity(amenity)}
+                              className="text-xs"
+                            >
+                              {amenity}
+                            </Button>
+                          ))}
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="flex flex-wrap gap-1">
+                        {room.amenities.slice(0, 3).map((amenity) => (
+                          <Badge key={amenity} variant="outline" className="text-xs">
+                            {amenity}
+                          </Badge>
+                        ))}
+                        {room.amenities.length > 3 && (
+                          <Badge variant="outline" className="text-xs">
+                            +{room.amenities.length - 3}
+                          </Badge>
+                        )}
+                      </div>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant={room.isActive ? "default" : "secondary"}>
+                      {room.isActive ? "アクティブ" : "非アクティブ"}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>
+                    {isEditing === room.id ? (
+                      <div className="flex gap-2">
+                        <Button size="sm" onClick={handleSave}>
+                          <Save className="h-4 w-4" />
+                        </Button>
+                        <Button size="sm" variant="outline" onClick={handleCancel}>
+                          <X className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    ) : (
+                      <div className="flex gap-2">
+                        <Button size="sm" variant="outline" onClick={() => handleEdit(room)}>
+                          <Edit className="h-4 w-4" />
+                        </Button>
+                        <Button size="sm" variant="destructive" onClick={() => handleDelete(room.id)}>
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    )}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/(dashboard)/settings/system/page.tsx
+++ b/app/(dashboard)/settings/system/page.tsx
@@ -1,0 +1,463 @@
+"use client"
+
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Badge } from "@/components/ui/badge"
+import { Separator } from "@/components/ui/separator"
+import { 
+  Save, 
+  Database, 
+  Mail, 
+  Bell, 
+  Shield, 
+  Settings2,
+  CheckCircle,
+  AlertTriangle
+} from "lucide-react"
+
+export default function SystemSettingsPage() {
+  const [settings, setSettings] = useState({
+    // データベース設定
+    database: {
+      host: process.env.NEXT_PUBLIC_SUPABASE_URL || "https://xxx.supabase.co",
+      status: "connected"
+    },
+    
+    // Board API設定
+    boardApi: {
+      endpoint: process.env.NEXT_PUBLIC_BOARD_API_URL || "",
+      apiKey: "••••••••••••••••",
+      status: "connected"
+    },
+    
+    // メール設定
+    email: {
+      smtpServer: "smtp.gmail.com",
+      smtpPort: 587,
+      username: "",
+      enableNotifications: true
+    },
+    
+    // 通知設定
+    notifications: {
+      newBooking: true,
+      paymentReceived: true,
+      cancellation: true,
+      dailyReport: false
+    },
+    
+    // システム設定
+    system: {
+      siteName: "淡路Reベース369",
+      timezone: "Asia/Tokyo",
+      language: "ja",
+      maintenanceMode: false,
+      debugMode: false
+    }
+  })
+
+  const [saveStatus, setSaveStatus] = useState<{ success: boolean; message: string } | null>(null)
+
+  const handleSave = () => {
+    // 実際の保存処理は省略（環境変数や設定ファイルへの書き込み）
+    setSaveStatus({
+      success: true,
+      message: "設定が正常に保存されました。"
+    })
+    
+    setTimeout(() => setSaveStatus(null), 3000)
+  }
+
+  const testConnection = (service: string) => {
+    // 接続テストの実装（実際にはAPIコールなど）
+    alert(`${service}への接続テストを実行しました。`)
+  }
+
+  return (
+    <div className="p-8">
+      <div className="flex justify-between items-center mb-8">
+        <div>
+          <h1 className="text-3xl font-bold">システム設定</h1>
+          <p className="text-muted-foreground">システム全般の設定と外部連携の管理</p>
+        </div>
+        <Button onClick={handleSave} className="flex items-center">
+          <Save className="mr-2 h-4 w-4" />
+          設定を保存
+        </Button>
+      </div>
+
+      {/* 保存状況表示 */}
+      {saveStatus && (
+        <Alert className={`mb-6 ${saveStatus.success ? 'border-green-500' : 'border-red-500'}`}>
+          <div className="flex items-center">
+            {saveStatus.success ? (
+              <CheckCircle className="h-4 w-4 text-green-500" />
+            ) : (
+              <AlertTriangle className="h-4 w-4 text-red-500" />
+            )}
+            <AlertDescription className="ml-2">{saveStatus.message}</AlertDescription>
+          </div>
+        </Alert>
+      )}
+
+      <Tabs defaultValue="database" className="space-y-6">
+        <TabsList className="grid w-full grid-cols-5">
+          <TabsTrigger value="database">データベース</TabsTrigger>
+          <TabsTrigger value="integrations">外部連携</TabsTrigger>
+          <TabsTrigger value="notifications">通知設定</TabsTrigger>
+          <TabsTrigger value="system">システム</TabsTrigger>
+          <TabsTrigger value="security">セキュリティ</TabsTrigger>
+        </TabsList>
+
+        {/* データベース設定 */}
+        <TabsContent value="database">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center">
+                <Database className="mr-2 h-5 w-5" />
+                データベース設定
+              </CardTitle>
+              <CardDescription>Supabaseデータベースの接続設定</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="db-url">データベースURL</Label>
+                  <Input
+                    id="db-url"
+                    value={settings.database.host}
+                    onChange={(e) => setSettings({
+                      ...settings,
+                      database: { ...settings.database, host: e.target.value }
+                    })}
+                    placeholder="https://xxx.supabase.co"
+                  />
+                </div>
+                
+                <div className="flex items-center justify-between">
+                  <div>
+                    <div className="font-medium">接続状況</div>
+                    <div className="text-sm text-muted-foreground">データベースへの接続状態</div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Badge variant={settings.database.status === "connected" ? "default" : "destructive"}>
+                      {settings.database.status === "connected" ? "接続中" : "切断"}
+                    </Badge>
+                    <Button size="sm" variant="outline" onClick={() => testConnection("データベース")}>
+                      接続テスト
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        {/* 外部連携設定 */}
+        <TabsContent value="integrations">
+          <div className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle>Board API連携</CardTitle>
+                <CardDescription>見積もり管理システムとの連携設定</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="board-endpoint">API エンドポイント</Label>
+                  <Input
+                    id="board-endpoint"
+                    value={settings.boardApi.endpoint}
+                    onChange={(e) => setSettings({
+                      ...settings,
+                      boardApi: { ...settings.boardApi, endpoint: e.target.value }
+                    })}
+                    placeholder="https://api.the-board.jp/v1"
+                  />
+                </div>
+                
+                <div className="space-y-2">
+                  <Label htmlFor="board-key">API キー</Label>
+                  <Input
+                    id="board-key"
+                    type="password"
+                    value={settings.boardApi.apiKey}
+                    onChange={(e) => setSettings({
+                      ...settings,
+                      boardApi: { ...settings.boardApi, apiKey: e.target.value }
+                    })}
+                    placeholder="API キーを入力"
+                  />
+                </div>
+
+                <div className="flex items-center justify-between">
+                  <div>
+                    <div className="font-medium">接続状況</div>
+                    <div className="text-sm text-muted-foreground">Board APIへの接続状態</div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Badge variant={settings.boardApi.status === "connected" ? "default" : "destructive"}>
+                      {settings.boardApi.status === "connected" ? "接続中" : "切断"}
+                    </Badge>
+                    <Button size="sm" variant="outline" onClick={() => testConnection("Board API")}>
+                      接続テスト
+                    </Button>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center">
+                  <Mail className="mr-2 h-5 w-5" />
+                  メール設定
+                </CardTitle>
+                <CardDescription>通知メール送信の設定</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="smtp-server">SMTPサーバー</Label>
+                    <Input
+                      id="smtp-server"
+                      value={settings.email.smtpServer}
+                      onChange={(e) => setSettings({
+                        ...settings,
+                        email: { ...settings.email, smtpServer: e.target.value }
+                      })}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="smtp-port">ポート</Label>
+                    <Input
+                      id="smtp-port"
+                      type="number"
+                      value={settings.email.smtpPort}
+                      onChange={(e) => setSettings({
+                        ...settings,
+                        email: { ...settings.email, smtpPort: parseInt(e.target.value) }
+                      })}
+                    />
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="email-username">ユーザー名</Label>
+                  <Input
+                    id="email-username"
+                    value={settings.email.username}
+                    onChange={(e) => setSettings({
+                      ...settings,
+                      email: { ...settings.email, username: e.target.value }
+                    })}
+                    placeholder="your-email@gmail.com"
+                  />
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </TabsContent>
+
+        {/* 通知設定 */}
+        <TabsContent value="notifications">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center">
+                <Bell className="mr-2 h-5 w-5" />
+                通知設定
+              </CardTitle>
+              <CardDescription>各種イベントの通知設定</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <div className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <div className="font-medium">新規予約通知</div>
+                    <div className="text-sm text-muted-foreground">新しい予約が入った時に通知</div>
+                  </div>
+                  <Switch
+                    checked={settings.notifications.newBooking}
+                    onCheckedChange={(checked) => setSettings({
+                      ...settings,
+                      notifications: { ...settings.notifications, newBooking: checked }
+                    })}
+                  />
+                </div>
+
+                <Separator />
+
+                <div className="flex items-center justify-between">
+                  <div>
+                    <div className="font-medium">支払い完了通知</div>
+                    <div className="text-sm text-muted-foreground">支払いが完了した時に通知</div>
+                  </div>
+                  <Switch
+                    checked={settings.notifications.paymentReceived}
+                    onCheckedChange={(checked) => setSettings({
+                      ...settings,
+                      notifications: { ...settings.notifications, paymentReceived: checked }
+                    })}
+                  />
+                </div>
+
+                <Separator />
+
+                <div className="flex items-center justify-between">
+                  <div>
+                    <div className="font-medium">キャンセル通知</div>
+                    <div className="text-sm text-muted-foreground">予約がキャンセルされた時に通知</div>
+                  </div>
+                  <Switch
+                    checked={settings.notifications.cancellation}
+                    onCheckedChange={(checked) => setSettings({
+                      ...settings,
+                      notifications: { ...settings.notifications, cancellation: checked }
+                    })}
+                  />
+                </div>
+
+                <Separator />
+
+                <div className="flex items-center justify-between">
+                  <div>
+                    <div className="font-medium">日次レポート</div>
+                    <div className="text-sm text-muted-foreground">毎日の売上・予約状況をメール送信</div>
+                  </div>
+                  <Switch
+                    checked={settings.notifications.dailyReport}
+                    onCheckedChange={(checked) => setSettings({
+                      ...settings,
+                      notifications: { ...settings.notifications, dailyReport: checked }
+                    })}
+                  />
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        {/* システム設定 */}
+        <TabsContent value="system">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center">
+                <Settings2 className="mr-2 h-5 w-5" />
+                システム設定
+              </CardTitle>
+              <CardDescription>基本的なシステム設定</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="site-name">サイト名</Label>
+                  <Input
+                    id="site-name"
+                    value={settings.system.siteName}
+                    onChange={(e) => setSettings({
+                      ...settings,
+                      system: { ...settings.system, siteName: e.target.value }
+                    })}
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="timezone">タイムゾーン</Label>
+                  <Input
+                    id="timezone"
+                    value={settings.system.timezone}
+                    onChange={(e) => setSettings({
+                      ...settings,
+                      system: { ...settings.system, timezone: e.target.value }
+                    })}
+                    disabled
+                  />
+                </div>
+
+                <Separator />
+
+                <div className="flex items-center justify-between">
+                  <div>
+                    <div className="font-medium">メンテナンスモード</div>
+                    <div className="text-sm text-muted-foreground">システムを一時的に停止</div>
+                  </div>
+                  <Switch
+                    checked={settings.system.maintenanceMode}
+                    onCheckedChange={(checked) => setSettings({
+                      ...settings,
+                      system: { ...settings.system, maintenanceMode: checked }
+                    })}
+                  />
+                </div>
+
+                <div className="flex items-center justify-between">
+                  <div>
+                    <div className="font-medium">デバッグモード</div>
+                    <div className="text-sm text-muted-foreground">詳細なログ出力を有効化</div>
+                  </div>
+                  <Switch
+                    checked={settings.system.debugMode}
+                    onCheckedChange={(checked) => setSettings({
+                      ...settings,
+                      system: { ...settings.system, debugMode: checked }
+                    })}
+                  />
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        {/* セキュリティ設定 */}
+        <TabsContent value="security">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center">
+                <Shield className="mr-2 h-5 w-5" />
+                セキュリティ設定
+              </CardTitle>
+              <CardDescription>認証とアクセス制御の設定</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <Alert>
+                <Shield className="h-4 w-4" />
+                <AlertDescription>
+                  セキュリティ設定の変更は、システム管理者のみが行うことができます。
+                  変更を行う前に、必ずバックアップを取得してください。
+                </AlertDescription>
+              </Alert>
+
+              <div className="space-y-4">
+                <div className="p-4 border rounded-lg">
+                  <h3 className="font-medium mb-2">認証方式</h3>
+                  <p className="text-sm text-muted-foreground">
+                    現在: Supabase Auth（メール/パスワード認証）
+                  </p>
+                </div>
+
+                <div className="p-4 border rounded-lg">
+                  <h3 className="font-medium mb-2">アクセス制御</h3>
+                  <p className="text-sm text-muted-foreground">
+                    Row Level Security（RLS）により、ユーザーは自分のデータのみアクセス可能
+                  </p>
+                </div>
+
+                <div className="p-4 border rounded-lg">
+                  <h3 className="font-medium mb-2">データ暗号化</h3>
+                  <p className="text-sm text-muted-foreground">
+                    すべてのデータはHTTPS/TLSで暗号化して転送・保存
+                  </p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}

--- a/components/booking/simple/BasicInfoStep.tsx
+++ b/components/booking/simple/BasicInfoStep.tsx
@@ -1,0 +1,284 @@
+"use client"
+
+import { useState } from "react"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { Calendar } from "@/components/ui/calendar"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { Badge } from "@/components/ui/badge"
+import { Separator } from "@/components/ui/separator"
+import { CalendarIcon, Plus, Minus, Users, User, Calendar as CalendarIconLucide } from "lucide-react"
+import { format } from "date-fns"
+import { ja } from "date-fns/locale"
+import { cn } from "@/lib/utils"
+import type { SimpleBookingFormData } from "./SimpleBookingWizard"
+
+interface BasicInfoStepProps {
+  formData: SimpleBookingFormData
+  onChange: (data: Partial<SimpleBookingFormData>) => void
+  availabilityResults?: any[]
+}
+
+export function BasicInfoStep({ formData, onChange, availabilityResults }: BasicInfoStepProps) {
+  const [startDate, setStartDate] = useState<Date | undefined>(
+    formData.dateRange.startDate ? new Date(formData.dateRange.startDate) : undefined
+  )
+  const [endDate, setEndDate] = useState<Date | undefined>(
+    formData.dateRange.endDate ? new Date(formData.dateRange.endDate) : undefined
+  )
+
+  const updateDateRange = (start: Date | undefined, end: Date | undefined) => {
+    if (start && end) {
+      const diffTime = Math.abs(end.getTime() - start.getTime())
+      const nights = Math.ceil(diffTime / (1000 * 60 * 60 * 24))
+      
+      onChange({
+        dateRange: {
+          startDate: start.toISOString().split('T')[0],
+          endDate: end.toISOString().split('T')[0],
+          nights: nights
+        }
+      })
+    }
+  }
+
+  const handleStartDateSelect = (date: Date | undefined) => {
+    setStartDate(date)
+    updateDateRange(date, endDate)
+  }
+
+  const handleEndDateSelect = (date: Date | undefined) => {
+    setEndDate(date)
+    updateDateRange(startDate, date)
+  }
+
+  const updateGuestCount = (type: keyof typeof formData.guests, change: number) => {
+    const newCount = Math.max(0, formData.guests[type] + change)
+    onChange({
+      guests: {
+        ...formData.guests,
+        [type]: newCount
+      }
+    })
+  }
+
+  const guestTypes = [
+    { key: "adult" as const, label: "大人", description: "中学生以上" },
+    { key: "student" as const, label: "学生", description: "小中高校生" },
+    { key: "child" as const, label: "小学生", description: "6-12歳" },
+    { key: "infant" as const, label: "幼児", description: "3-5歳" },
+    { key: "baby" as const, label: "乳児", description: "0-2歳" },
+  ]
+
+  const totalGuests = Object.values(formData.guests).reduce((sum, count) => sum + count, 0)
+
+  return (
+    <div className="space-y-8">
+      {/* 日程選択 */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center">
+            <CalendarIconLucide className="mr-2 h-5 w-5" />
+            宿泊期間
+          </CardTitle>
+          <CardDescription>チェックイン・チェックアウト日を選択してください</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label>チェックイン日</Label>
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button
+                    variant="outline"
+                    className={cn(
+                      "w-full justify-start text-left font-normal",
+                      !startDate && "text-muted-foreground"
+                    )}
+                  >
+                    <CalendarIcon className="mr-2 h-4 w-4" />
+                    {startDate ? format(startDate, "yyyy年MM月dd日", { locale: ja }) : "日付を選択"}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-auto p-0" align="start">
+                  <Calendar
+                    mode="single"
+                    selected={startDate}
+                    onSelect={handleStartDateSelect}
+                    disabled={(date) => date < new Date()}
+                    initialFocus
+                  />
+                </PopoverContent>
+              </Popover>
+            </div>
+
+            <div className="space-y-2">
+              <Label>チェックアウト日</Label>
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button
+                    variant="outline"
+                    className={cn(
+                      "w-full justify-start text-left font-normal",
+                      !endDate && "text-muted-foreground"
+                    )}
+                  >
+                    <CalendarIcon className="mr-2 h-4 w-4" />
+                    {endDate ? format(endDate, "yyyy年MM月dd日", { locale: ja }) : "日付を選択"}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-auto p-0" align="start">
+                  <Calendar
+                    mode="single"
+                    selected={endDate}
+                    onSelect={handleEndDateSelect}
+                    disabled={(date) => date < new Date() || (startDate && date <= startDate)}
+                    initialFocus
+                  />
+                </PopoverContent>
+              </Popover>
+            </div>
+          </div>
+
+          {formData.dateRange.nights > 0 && (
+            <div className="text-center p-4 bg-muted rounded-lg">
+              <div className="font-semibold text-lg">
+                {formData.dateRange.nights}泊 {formData.dateRange.nights + 1}日
+              </div>
+              <div className="text-sm text-muted-foreground">
+                {startDate && endDate && (
+                  <>
+                    {format(startDate, "MM月dd日", { locale: ja })} ～ {format(endDate, "MM月dd日", { locale: ja })}
+                  </>
+                )}
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* 人数選択 */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center">
+            <Users className="mr-2 h-5 w-5" />
+            宿泊者数
+          </CardTitle>
+          <CardDescription>年齢区分別に人数を設定してください</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {guestTypes.map((guestType) => (
+            <div key={guestType.key} className="flex items-center justify-between p-4 border rounded-lg">
+              <div className="flex-1">
+                <div className="font-medium">{guestType.label}</div>
+                <div className="text-sm text-muted-foreground">{guestType.description}</div>
+              </div>
+              <div className="flex items-center gap-3">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => updateGuestCount(guestType.key, -1)}
+                  disabled={formData.guests[guestType.key] === 0}
+                >
+                  <Minus className="h-4 w-4" />
+                </Button>
+                <span className="w-8 text-center font-medium">
+                  {formData.guests[guestType.key]}
+                </span>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => updateGuestCount(guestType.key, 1)}
+                >
+                  <Plus className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+          ))}
+
+          {totalGuests > 0 && (
+            <div className="text-center p-4 bg-muted rounded-lg">
+              <div className="font-semibold text-lg flex items-center justify-center">
+                <Users className="mr-2 h-5 w-5" />
+                合計 {totalGuests}名
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Separator />
+
+      {/* 代表者情報 */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center">
+            <User className="mr-2 h-5 w-5" />
+            代表者情報
+          </CardTitle>
+          <CardDescription>予約代表者の連絡先を入力してください</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="guestName">代表者名 *</Label>
+              <Input
+                id="guestName"
+                value={formData.guestName}
+                onChange={(e) => onChange({ guestName: e.target.value })}
+                placeholder="山田 太郎"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="guestOrg">団体・組織名</Label>
+              <Input
+                id="guestOrg"
+                value={formData.guestOrg}
+                onChange={(e) => onChange({ guestOrg: e.target.value })}
+                placeholder="関西大学"
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="guestEmail">メールアドレス *</Label>
+              <Input
+                id="guestEmail"
+                type="email"
+                value={formData.guestEmail}
+                onChange={(e) => onChange({ guestEmail: e.target.value })}
+                placeholder="example@email.com"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="guestPhone">電話番号 *</Label>
+              <Input
+                id="guestPhone"
+                type="tel"
+                value={formData.guestPhone}
+                onChange={(e) => onChange({ guestPhone: e.target.value })}
+                placeholder="090-1234-5678"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="purpose">利用目的</Label>
+            <Input
+              id="purpose"
+              value={formData.purpose}
+              onChange={(e) => onChange({ purpose: e.target.value })}
+              placeholder="研修・合宿・会議など"
+            />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/components/booking/simple/ConfirmationStep.tsx
+++ b/components/booking/simple/ConfirmationStep.tsx
@@ -1,0 +1,279 @@
+"use client"
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Separator } from "@/components/ui/separator"
+import { Textarea } from "@/components/ui/textarea"
+import { Label } from "@/components/ui/label"
+import { Calendar, Users, Home, ShoppingCart, User, Mail, Phone, Building } from "lucide-react"
+import { format } from "date-fns"
+import { ja } from "date-fns/locale"
+import type { SimpleBookingFormData } from "./SimpleBookingWizard"
+
+interface ConfirmationStepProps {
+  formData: SimpleBookingFormData
+  priceBreakdown?: any
+  onChange: (data: Partial<SimpleBookingFormData>) => void
+}
+
+// モックルームデータ - 実際はAPIから取得
+const ROOMS = [
+  { id: "R201", name: "201号室", floor: "2F", type: "standard", capacity: 4, basePrice: 15000 },
+  { id: "R202", name: "202号室", floor: "2F", type: "standard", capacity: 4, basePrice: 15000 },
+  { id: "R203", name: "203号室", floor: "2F", type: "large", capacity: 6, basePrice: 18000 },
+  { id: "R204", name: "204号室", floor: "2F", type: "standard", capacity: 4, basePrice: 15000 },
+  { id: "R205", name: "205号室", floor: "2F", type: "suite", capacity: 8, basePrice: 22000 },
+  { id: "R301", name: "301号室", floor: "3F", type: "standard", capacity: 4, basePrice: 15000 },
+  { id: "R302", name: "302号室", floor: "3F", type: "standard", capacity: 4, basePrice: 15000 },
+  { id: "R303", name: "303号室", floor: "3F", type: "large", capacity: 6, basePrice: 18000 },
+  { id: "R304", name: "304号室", floor: "3F", type: "standard", capacity: 4, basePrice: 15000 },
+  { id: "R305", name: "305号室", floor: "3F", type: "standard", capacity: 4, basePrice: 15000 },
+  { id: "R306", name: "306号室", floor: "3F", type: "large", capacity: 6, basePrice: 18000 },
+  { id: "R307", name: "307号室", floor: "3F", type: "suite", capacity: 8, basePrice: 22000 },
+]
+
+// モックオプションデータ
+const OPTIONS = [
+  { id: "meal_breakfast", name: "朝食", price: 800, unit: "人/日" },
+  { id: "meal_lunch", name: "昼食", price: 1200, unit: "人/日" },
+  { id: "meal_dinner", name: "夕食", price: 2000, unit: "人/日" },
+  { id: "facility_meeting", name: "会議室利用", price: 3000, unit: "日" },
+  { id: "facility_parking", name: "駐車場", price: 500, unit: "台/日" },
+  { id: "equipment_futon", name: "追加布団", price: 1000, unit: "組/日" },
+]
+
+export function ConfirmationStep({ formData, priceBreakdown, onChange }: ConfirmationStepProps) {
+  const totalGuests = Object.values(formData.guests).reduce((sum, count) => sum + count, 0)
+  const selectedRoomData = ROOMS.filter(room => formData.selectedRooms.includes(room.id))
+  const totalCapacity = selectedRoomData.reduce((sum, room) => sum + room.capacity, 0)
+
+  const startDate = formData.dateRange.startDate ? new Date(formData.dateRange.startDate) : null
+  const endDate = formData.dateRange.endDate ? new Date(formData.dateRange.endDate) : null
+
+  const guestTypes = [
+    { key: "adult" as const, label: "大人" },
+    { key: "student" as const, label: "学生" },
+    { key: "child" as const, label: "小学生" },
+    { key: "infant" as const, label: "幼児" },
+    { key: "baby" as const, label: "乳児" },
+  ]
+
+  const getRoomTypeLabel = (type: string) => {
+    switch (type) {
+      case "standard": return "スタンダード"
+      case "large": return "ラージ"
+      case "suite": return "スイート"
+      default: return type
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* 宿泊情報確認 */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center">
+            <Calendar className="mr-2 h-5 w-5" />
+            宿泊情報
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <div className="text-sm text-muted-foreground">宿泊期間</div>
+              <div className="font-medium">
+                {startDate && endDate && (
+                  <>
+                    {format(startDate, "yyyy年MM月dd日", { locale: ja })} ～ {format(endDate, "yyyy年MM月dd日", { locale: ja })}
+                  </>
+                )}
+              </div>
+              <div className="text-sm text-muted-foreground">
+                {formData.dateRange.nights}泊{formData.dateRange.nights + 1}日
+              </div>
+            </div>
+
+            <div>
+              <div className="text-sm text-muted-foreground">宿泊者数</div>
+              <div className="font-medium flex items-center">
+                <Users className="mr-1 h-4 w-4" />
+                合計 {totalGuests}名
+              </div>
+              <div className="text-sm text-muted-foreground">
+                {guestTypes.map(type => 
+                  formData.guests[type.key] > 0 && (
+                    <span key={type.key} className="mr-2">
+                      {type.label}: {formData.guests[type.key]}名
+                    </span>
+                  )
+                )}
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* 代表者情報確認 */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center">
+            <User className="mr-2 h-5 w-5" />
+            代表者情報
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="flex items-center space-x-2">
+              <User className="h-4 w-4 text-muted-foreground" />
+              <span className="font-medium">{formData.guestName}</span>
+            </div>
+            {formData.guestOrg && (
+              <div className="flex items-center space-x-2">
+                <Building className="h-4 w-4 text-muted-foreground" />
+                <span>{formData.guestOrg}</span>
+              </div>
+            )}
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="flex items-center space-x-2">
+              <Mail className="h-4 w-4 text-muted-foreground" />
+              <span>{formData.guestEmail}</span>
+            </div>
+            <div className="flex items-center space-x-2">
+              <Phone className="h-4 w-4 text-muted-foreground" />
+              <span>{formData.guestPhone}</span>
+            </div>
+          </div>
+          {formData.purpose && (
+            <div>
+              <div className="text-sm text-muted-foreground">利用目的</div>
+              <div>{formData.purpose}</div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* 選択部屋確認 */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center">
+            <Home className="mr-2 h-5 w-5" />
+            選択部屋
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            {selectedRoomData.map((room) => (
+              <div key={room.id} className="flex items-center justify-between p-3 border rounded-lg">
+                <div className="flex items-center space-x-3">
+                  <Badge variant="outline">{room.floor}</Badge>
+                  <span className="font-medium">{room.name}</span>
+                  <Badge variant="secondary">{getRoomTypeLabel(room.type)}</Badge>
+                </div>
+                <div className="text-right">
+                  <div className="font-medium">¥{room.basePrice.toLocaleString()}</div>
+                  <div className="text-sm text-muted-foreground">定員{room.capacity}名</div>
+                </div>
+              </div>
+            ))}
+            <div className="pt-3 border-t">
+              <div className="flex justify-between text-sm text-muted-foreground">
+                <span>合計定員</span>
+                <span>{totalCapacity}名</span>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* オプション確認 */}
+      {formData.selectedAddons.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center">
+              <ShoppingCart className="mr-2 h-5 w-5" />
+              選択オプション
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-3">
+              {formData.selectedAddons.map((addon) => {
+                const optionData = OPTIONS.find(opt => opt.id === addon.id)
+                if (!optionData) return null
+
+                return (
+                  <div key={addon.id} className="flex items-center justify-between p-3 border rounded-lg">
+                    <div className="flex items-center space-x-3">
+                      <span className="font-medium">{optionData.name}</span>
+                      <Badge variant="outline">数量: {addon.quantity}</Badge>
+                    </div>
+                    <div className="text-right">
+                      <div className="font-medium">
+                        ¥{(optionData.price * addon.quantity).toLocaleString()}
+                      </div>
+                      <div className="text-sm text-muted-foreground">
+                        ¥{optionData.price.toLocaleString()} × {addon.quantity}
+                      </div>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* 料金詳細 */}
+      {priceBreakdown && (
+        <Card>
+          <CardHeader>
+            <CardTitle>料金詳細</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-3">
+              <div className="flex justify-between">
+                <span>室料</span>
+                <span>¥{priceBreakdown.roomAmount?.toLocaleString()}</span>
+              </div>
+              <div className="flex justify-between">
+                <span>個人料金</span>
+                <span>¥{priceBreakdown.guestAmount?.toLocaleString()}</span>
+              </div>
+              <div className="flex justify-between">
+                <span>オプション</span>
+                <span>¥{priceBreakdown.addonAmount?.toLocaleString()}</span>
+              </div>
+              <Separator />
+              <div className="flex justify-between text-lg font-bold">
+                <span>合計金額（税込）</span>
+                <span>¥{priceBreakdown.total?.toLocaleString()}</span>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* 備考 */}
+      <Card>
+        <CardHeader>
+          <CardTitle>備考・特記事項</CardTitle>
+          <CardDescription>
+            その他ご要望や特記事項がございましたらご記入ください
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2">
+            <Label htmlFor="notes">備考</Label>
+            <Textarea
+              id="notes"
+              value={formData.notes}
+              onChange={(e) => onChange({ notes: e.target.value })}
+              placeholder="アレルギー情報、アクセス方法、その他ご要望など"
+              rows={4}
+            />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/components/booking/simple/RoomAndOptionsStep.tsx
+++ b/components/booking/simple/RoomAndOptionsStep.tsx
@@ -1,0 +1,394 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Label } from "@/components/ui/label"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Home, ShoppingCart, Users, CheckCircle, AlertCircle, Bed, Utensils, Briefcase } from "lucide-react"
+import { cn } from "@/lib/utils"
+import type { SimpleBookingFormData } from "./SimpleBookingWizard"
+
+interface RoomAndOptionsStepProps {
+  formData: SimpleBookingFormData
+  onChange: (data: Partial<SimpleBookingFormData>) => void
+  availabilityResults?: any[]
+  priceBreakdown?: any
+}
+
+// モックルームデータ - 実際はAPIから取得
+const ROOMS = [
+  { id: "R201", name: "201号室", floor: "2F", type: "standard", capacity: 4, basePrice: 15000 },
+  { id: "R202", name: "202号室", floor: "2F", type: "standard", capacity: 4, basePrice: 15000 },
+  { id: "R203", name: "203号室", floor: "2F", type: "large", capacity: 6, basePrice: 18000 },
+  { id: "R204", name: "204号室", floor: "2F", type: "standard", capacity: 4, basePrice: 15000 },
+  { id: "R205", name: "205号室", floor: "2F", type: "suite", capacity: 8, basePrice: 22000 },
+  { id: "R301", name: "301号室", floor: "3F", type: "standard", capacity: 4, basePrice: 15000 },
+  { id: "R302", name: "302号室", floor: "3F", type: "standard", capacity: 4, basePrice: 15000 },
+  { id: "R303", name: "303号室", floor: "3F", type: "large", capacity: 6, basePrice: 18000 },
+  { id: "R304", name: "304号室", floor: "3F", type: "standard", capacity: 4, basePrice: 15000 },
+  { id: "R305", name: "305号室", floor: "3F", type: "standard", capacity: 4, basePrice: 15000 },
+  { id: "R306", name: "306号室", floor: "3F", type: "large", capacity: 6, basePrice: 18000 },
+  { id: "R307", name: "307号室", floor: "3F", type: "suite", capacity: 8, basePrice: 22000 },
+]
+
+// モックオプションデータ
+const OPTIONS = [
+  {
+    id: "meal_breakfast",
+    category: "食事",
+    name: "朝食",
+    description: "和洋バイキング",
+    price: 800,
+    unit: "人/日",
+    icon: Utensils
+  },
+  {
+    id: "meal_lunch",
+    category: "食事", 
+    name: "昼食",
+    description: "お弁当またはバイキング",
+    price: 1200,
+    unit: "人/日",
+    icon: Utensils
+  },
+  {
+    id: "meal_dinner",
+    category: "食事",
+    name: "夕食",
+    description: "BBQまたは和食",
+    price: 2000,
+    unit: "人/日",
+    icon: Utensils
+  },
+  {
+    id: "facility_meeting",
+    category: "施設",
+    name: "会議室利用",
+    description: "プロジェクター・ホワイトボード付き",
+    price: 3000,
+    unit: "日",
+    icon: Briefcase
+  },
+  {
+    id: "facility_parking",
+    category: "施設",
+    name: "駐車場",
+    description: "1台あたり",
+    price: 500,
+    unit: "台/日",
+    icon: Home
+  },
+  {
+    id: "equipment_futon",
+    category: "備品",
+    name: "追加布団",
+    description: "1組あたり",
+    price: 1000,
+    unit: "組/日",
+    icon: Bed
+  },
+]
+
+export function RoomAndOptionsStep({ formData, onChange, availabilityResults, priceBreakdown }: RoomAndOptionsStepProps) {
+  const [selectedFloor, setSelectedFloor] = useState<string>("all")
+
+  const totalGuests = Object.values(formData.guests).reduce((sum, count) => sum + count, 0)
+
+  // 利用可能な部屋を計算
+  const getAvailableRooms = () => {
+    if (!availabilityResults || availabilityResults.length === 0) {
+      return ROOMS.map(room => ({ ...room, isAvailable: true }))
+    }
+
+    return ROOMS.map(room => {
+      const availability = availabilityResults.find(result => result.roomId === room.id)
+      return {
+        ...room,
+        isAvailable: availability ? availability.isAvailable : true
+      }
+    })
+  }
+
+  const availableRooms = getAvailableRooms()
+  const filteredRooms = selectedFloor === "all" 
+    ? availableRooms 
+    : availableRooms.filter(room => room.floor === selectedFloor)
+
+  // 定員チェック
+  const getCapacityStatus = () => {
+    const selectedRoomData = ROOMS.filter(room => formData.selectedRooms.includes(room.id))
+    const totalCapacity = selectedRoomData.reduce((sum, room) => sum + room.capacity, 0)
+    
+    return {
+      totalCapacity,
+      isValid: totalCapacity >= totalGuests,
+      isOptimal: totalCapacity >= totalGuests && totalCapacity <= totalGuests + 2
+    }
+  }
+
+  const capacityStatus = getCapacityStatus()
+
+  const toggleRoom = (roomId: string) => {
+    const newSelectedRooms = formData.selectedRooms.includes(roomId)
+      ? formData.selectedRooms.filter(id => id !== roomId)
+      : [...formData.selectedRooms, roomId]
+    
+    onChange({ selectedRooms: newSelectedRooms })
+  }
+
+  const toggleOption = (optionId: string) => {
+    const newSelectedOptions = formData.selectedAddons.some(addon => addon.id === optionId)
+      ? formData.selectedAddons.filter(addon => addon.id !== optionId)
+      : [...formData.selectedAddons, { id: optionId, quantity: 1 }]
+    
+    onChange({ selectedAddons: newSelectedOptions })
+  }
+
+  const updateOptionQuantity = (optionId: string, quantity: number) => {
+    const newSelectedOptions = formData.selectedAddons.map(addon =>
+      addon.id === optionId ? { ...addon, quantity: Math.max(0, quantity) } : addon
+    ).filter(addon => addon.quantity > 0)
+    
+    onChange({ selectedAddons: newSelectedOptions })
+  }
+
+  const getRoomTypeLabel = (type: string) => {
+    switch (type) {
+      case "standard": return "スタンダード"
+      case "large": return "ラージ"
+      case "suite": return "スイート"
+      default: return type
+    }
+  }
+
+  const getRoomTypeColor = (type: string) => {
+    switch (type) {
+      case "standard": return "bg-blue-100 text-blue-800"
+      case "large": return "bg-green-100 text-green-800"
+      case "suite": return "bg-purple-100 text-purple-800"
+      default: return "bg-gray-100 text-gray-800"
+    }
+  }
+
+  return (
+    <div className="space-y-8">
+      {/* 部屋選択 */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center">
+            <Home className="mr-2 h-5 w-5" />
+            部屋選択
+          </CardTitle>
+          <CardDescription>
+            宿泊者 {totalGuests}名に適した部屋を選択してください
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {/* フロア選択 */}
+          <div className="flex gap-2">
+            <Button
+              variant={selectedFloor === "all" ? "default" : "outline"}
+              size="sm"
+              onClick={() => setSelectedFloor("all")}
+            >
+              全フロア
+            </Button>
+            <Button
+              variant={selectedFloor === "2F" ? "default" : "outline"}
+              size="sm"
+              onClick={() => setSelectedFloor("2F")}
+            >
+              2階
+            </Button>
+            <Button
+              variant={selectedFloor === "3F" ? "default" : "outline"}
+              size="sm"
+              onClick={() => setSelectedFloor("3F")}
+            >
+              3階
+            </Button>
+          </div>
+
+          {/* 定員状況 */}
+          {formData.selectedRooms.length > 0 && (
+            <Alert variant={capacityStatus.isValid ? "default" : "destructive"}>
+              <Users className="h-4 w-4" />
+              <AlertDescription>
+                <div className="flex items-center justify-between">
+                  <span>
+                    定員: {capacityStatus.totalCapacity}名 / 宿泊者: {totalGuests}名
+                  </span>
+                  {capacityStatus.isValid ? (
+                    <Badge variant="default" className="flex items-center">
+                      <CheckCircle className="w-3 h-3 mr-1" />
+                      OK
+                    </Badge>
+                  ) : (
+                    <Badge variant="destructive" className="flex items-center">
+                      <AlertCircle className="w-3 h-3 mr-1" />
+                      定員不足
+                    </Badge>
+                  )}
+                </div>
+                {!capacityStatus.isOptimal && capacityStatus.isValid && (
+                  <div className="text-sm text-muted-foreground mt-1">
+                    定員に余裕があります。より効率的な部屋選択をご検討ください。
+                  </div>
+                )}
+              </AlertDescription>
+            </Alert>
+          )}
+
+          {/* 部屋一覧 */}
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {filteredRooms.map((room) => {
+              const isSelected = formData.selectedRooms.includes(room.id)
+              const isAvailable = room.isAvailable
+
+              return (
+                <Card
+                  key={room.id}
+                  className={cn(
+                    "cursor-pointer transition-all",
+                    isSelected && "ring-2 ring-primary",
+                    !isAvailable && "opacity-50 cursor-not-allowed"
+                  )}
+                  onClick={() => isAvailable && toggleRoom(room.id)}
+                >
+                  <CardContent className="p-4">
+                    <div className="flex items-center justify-between mb-2">
+                      <div className="font-medium">{room.name}</div>
+                      <Badge variant="outline" className={getRoomTypeColor(room.type)}>
+                        {getRoomTypeLabel(room.type)}
+                      </Badge>
+                    </div>
+                    
+                    <div className="space-y-2 text-sm text-muted-foreground">
+                      <div className="flex items-center justify-between">
+                        <span>定員</span>
+                        <span>{room.capacity}名</span>
+                      </div>
+                      <div className="flex items-center justify-between">
+                        <span>基本料金</span>
+                        <span>¥{room.basePrice.toLocaleString()}</span>
+                      </div>
+                      <div className="flex items-center justify-between">
+                        <span>状態</span>
+                        <Badge variant={isAvailable ? "default" : "secondary"}>
+                          {isAvailable ? "空室" : "満室"}
+                        </Badge>
+                      </div>
+                    </div>
+
+                    {isSelected && (
+                      <div className="mt-3 pt-3 border-t">
+                        <Badge variant="default" className="w-full justify-center">
+                          <CheckCircle className="w-3 h-3 mr-1" />
+                          選択中
+                        </Badge>
+                      </div>
+                    )}
+                  </CardContent>
+                </Card>
+              )
+            })}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* オプション選択 */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center">
+            <ShoppingCart className="mr-2 h-5 w-5" />
+            オプション
+          </CardTitle>
+          <CardDescription>必要なオプションサービスを選択してください</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {["食事", "施設", "備品"].map((category) => (
+            <div key={category}>
+              <h4 className="font-medium mb-3">{category}</h4>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                {OPTIONS.filter(option => option.category === category).map((option) => {
+                  const selectedOption = formData.selectedAddons.find(addon => addon.id === option.id)
+                  const isSelected = !!selectedOption
+                  const Icon = option.icon
+
+                  return (
+                    <Card
+                      key={option.id}
+                      className={cn(
+                        "cursor-pointer transition-all",
+                        isSelected && "ring-2 ring-primary"
+                      )}
+                    >
+                      <CardContent className="p-4">
+                        <div className="flex items-start justify-between">
+                          <div className="flex items-start space-x-3 flex-1">
+                            <Checkbox
+                              checked={isSelected}
+                              onCheckedChange={() => toggleOption(option.id)}
+                            />
+                            <div className="flex-1">
+                              <div className="flex items-center space-x-2">
+                                <Icon className="w-4 h-4" />
+                                <span className="font-medium">{option.name}</span>
+                              </div>
+                              <p className="text-sm text-muted-foreground mt-1">
+                                {option.description}
+                              </p>
+                              <div className="text-sm font-medium mt-2">
+                                ¥{option.price.toLocaleString()} / {option.unit}
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+
+                        {isSelected && (
+                          <div className="mt-4 pt-4 border-t">
+                            <div className="flex items-center justify-between">
+                              <Label>数量</Label>
+                              <div className="flex items-center space-x-2">
+                                <Button
+                                  variant="outline"
+                                  size="sm"
+                                  onClick={(e) => {
+                                    e.stopPropagation()
+                                    updateOptionQuantity(option.id, (selectedOption?.quantity || 1) - 1)
+                                  }}
+                                >
+                                  -
+                                </Button>
+                                <span className="w-8 text-center">
+                                  {selectedOption?.quantity || 1}
+                                </span>
+                                <Button
+                                  variant="outline"
+                                  size="sm"
+                                  onClick={(e) => {
+                                    e.stopPropagation()
+                                    updateOptionQuantity(option.id, (selectedOption?.quantity || 1) + 1)
+                                  }}
+                                >
+                                  +
+                                </Button>
+                              </div>
+                            </div>
+                          </div>
+                        )}
+                      </CardContent>
+                    </Card>
+                  )
+                })}
+              </div>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/components/booking/simple/SimpleBookingWizard.tsx
+++ b/components/booking/simple/SimpleBookingWizard.tsx
@@ -1,0 +1,531 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { useRouter } from "next/navigation"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { Progress } from "@/components/ui/progress"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Calendar, Home, CheckCircle, AlertCircle } from "lucide-react"
+import { BasicInfoStep } from "./BasicInfoStep"
+import { RoomAndOptionsStep } from "./RoomAndOptionsStep"
+import { ConfirmationStep } from "./ConfirmationStep"
+import { useAvailability } from "@/lib/hooks/use-availability"
+import { usePricing } from "@/lib/hooks/use-pricing"
+import { useDoubleBookingPrevention } from "@/lib/hooks/use-double-booking-prevention"
+import { useToast } from "@/hooks/use-toast"
+import type { GuestCount } from "@/lib/pricing/types"
+
+interface SimpleBookingWizardProps {
+  onComplete?: (bookingData: any) => void
+  initialData?: Partial<SimpleBookingFormData>
+}
+
+export interface SimpleBookingFormData {
+  // Step 1: 基本情報 (日程・人数・代表者)
+  dateRange: {
+    startDate: string
+    endDate: string
+    nights: number
+  }
+  guests: GuestCount
+  guestName: string
+  guestEmail: string
+  guestPhone: string
+  guestOrg: string
+  purpose: string
+  
+  // Step 2: 部屋・オプション統合
+  selectedRooms: string[]
+  selectedAddons: any[]
+  
+  // その他
+  notes: string
+}
+
+const SIMPLIFIED_WIZARD = [
+  { step: 1, title: "📅 基本情報", desc: "日程・人数・代表者" },
+  { step: 2, title: "🏠 部屋・オプション", desc: "部屋選択とオプション統合" },
+  { step: 3, title: "✅ 確認・完了", desc: "見積・予約確定" },
+]
+
+export function SimpleBookingWizard({ onComplete, initialData }: SimpleBookingWizardProps) {
+  const router = useRouter()
+  const [currentStep, setCurrentStep] = useState(1)
+  const [formData, setFormData] = useState<SimpleBookingFormData>({
+    dateRange: { startDate: "", endDate: "", nights: 0 },
+    guests: { adult: 0, student: 0, child: 0, infant: 0, baby: 0 },
+    guestName: "",
+    guestEmail: "",
+    guestPhone: "",
+    guestOrg: "",
+    purpose: "",
+    selectedRooms: [],
+    selectedAddons: [],
+    notes: "",
+    ...initialData,
+  })
+
+  const [validationErrors, setValidationErrors] = useState<string[]>([])
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [conflictWarnings, setConflictWarnings] = useState<string[]>([])
+  const [hasActiveConflicts, setHasActiveConflicts] = useState(false)
+
+  const { checkAvailability } = useAvailability()
+  const { calculateBookingPrice, validateGuestCapacity } = usePricing()
+  const {
+    checkForConflicts,
+    finalValidation,
+    acquireLock,
+    hasConflicts,
+    hasLock,
+    isLockExpiring,
+    otherActiveSessions,
+    conflicts,
+    getConflictSummary,
+    reset: resetConflictState
+  } = useDoubleBookingPrevention({ autoCheck: true, checkInterval: 30000 })
+  const { toast } = useToast()
+
+  const [priceBreakdown, setPriceBreakdown] = useState<any>(null)
+  const [availabilityResults, setAvailabilityResults] = useState<any[]>([])
+
+  // リアルタイム料金計算と競合チェック
+  useEffect(() => {
+    if (formData.selectedRooms.length > 0 && formData.dateRange.nights > 0) {
+      calculatePrice()
+      performRealtimeConflictCheck()
+    }
+  }, [formData.selectedRooms, formData.guests, formData.dateRange, formData.selectedAddons])
+
+  // 競合状態の監視とユーザー通知
+  useEffect(() => {
+    if (hasConflicts) {
+      const summary = getConflictSummary()
+      setHasActiveConflicts(true)
+      setConflictWarnings([
+        `${summary?.totalConflicts}件の予約競合が検出されました`,
+        `影響部屋: ${summary?.roomNames}`,
+        '別の部屋または日程をご検討ください'
+      ])
+      
+      toast({
+        title: "⚠️ 予約競合が検出されました",
+        description: `${summary?.affectedRooms}室で重複が発生しています`,
+        variant: "destructive"
+      })
+    } else {
+      setHasActiveConflicts(false)
+      setConflictWarnings([])
+    }
+  }, [hasConflicts, conflicts, toast])
+
+  // 他ユーザーのアクティブセッション監視
+  useEffect(() => {
+    if (otherActiveSessions > 0) {
+      toast({
+        title: "👥 他のユーザーが同じ期間を検討中です",
+        description: `${otherActiveSessions}名のユーザーが同時に予約を検討しています`,
+        variant: "default"
+      })
+    }
+  }, [otherActiveSessions, toast])
+
+  // ロック期限切れ警告
+  useEffect(() => {
+    if (isLockExpiring && hasLock) {
+      toast({
+        title: "⏰ 予約ロックの期限が近づいています",
+        description: "1分以内にロックが解除されます。お早めに完了してください",
+        variant: "destructive"
+      })
+    }
+  }, [isLockExpiring, hasLock, toast])
+
+  const calculatePrice = async () => {
+    try {
+      const totalGuests = Object.values(formData.guests).reduce((sum, count) => sum + count, 0)
+      if (totalGuests === 0) return
+
+      const breakdown = await calculateBookingPrice({
+        rooms: formData.selectedRooms,
+        guests: formData.guests,
+        dateRange: formData.dateRange,
+        addons: formData.selectedAddons,
+      })
+
+      setPriceBreakdown(breakdown)
+    } catch (error) {
+      console.error("料金計算エラー:", error)
+    }
+  }
+
+  // リアルタイム競合チェック
+  const performRealtimeConflictCheck = async () => {
+    if (!formData.dateRange.startDate || !formData.dateRange.endDate || formData.selectedRooms.length === 0) {
+      return
+    }
+
+    try {
+      const result = await checkForConflicts(
+        formData.selectedRooms,
+        formData.dateRange.startDate,
+        formData.dateRange.endDate
+      )
+
+      if (!result.success && result.conflicts.length > 0) {
+        toast({
+          title: "⚠️ 予約競合が検出されました",
+          description: "別の部屋または日程をご検討ください",
+          variant: "destructive"
+        })
+      }
+    } catch (error) {
+      console.error("リアルタイム競合チェックエラー:", error)
+    }
+  }
+
+  const validateCurrentStep = (): boolean => {
+    const errors: string[] = []
+
+    switch (currentStep) {
+      case 1:
+        if (!formData.dateRange.startDate || !formData.dateRange.endDate) {
+          errors.push("宿泊期間を選択してください")
+        }
+        if (formData.dateRange.nights <= 0) {
+          errors.push("宿泊日数が正しくありません")
+        }
+        const totalGuests = Object.values(formData.guests).reduce((sum, count) => sum + count, 0)
+        if (totalGuests === 0) {
+          errors.push("宿泊者数を入力してください")
+        }
+        if (totalGuests > 100) {
+          errors.push("宿泊者数が上限を超えています（最大100名）")
+        }
+        if (!formData.guestName) errors.push("代表者名を入力してください")
+        if (!formData.guestEmail) errors.push("メールアドレスを入力してください")
+        if (!formData.guestPhone) errors.push("電話番号を入力してください")
+        break
+
+      case 2:
+        if (formData.selectedRooms.length === 0) {
+          errors.push("部屋を選択してください")
+        }
+        
+        const validation = validateGuestCapacity(formData.selectedRooms, formData.guests)
+        if (!validation.isValid) {
+          errors.push(validation.message || "定員超過です")
+        }
+        break
+
+      case 3:
+        // 最終確認は前ステップで検証済み
+        break
+    }
+
+    setValidationErrors(errors)
+    return errors.length === 0
+  }
+
+  const handleNext = async () => {
+    if (!validateCurrentStep()) return
+
+    // 重複があれば進行を阻止
+    if (hasActiveConflicts) {
+      toast({
+        title: "❌ 予約競合のため進行できません",
+        description: "競合を解決してから次のステップに進んでください",
+        variant: "destructive"
+      })
+      return
+    }
+
+    // Step 1完了時: 空室チェック
+    if (currentStep === 1) {
+      await checkRoomAvailability()
+    }
+
+    // Step 2完了時: 予約ロック取得
+    if (currentStep === 2 && formData.selectedRooms.length > 0) {
+      const lockAcquired = await acquireLock(
+        formData.selectedRooms,
+        formData.dateRange.startDate,
+        formData.dateRange.endDate
+      )
+
+      if (!lockAcquired) {
+        toast({
+          title: "🔒 予約ロックの取得に失敗しました",
+          description: "他のユーザーが同じ部屋・期間を予約中です。しばらく待ってからお試しください",
+          variant: "destructive"
+        })
+        return
+      }
+
+      toast({
+        title: "🔐 予約ロックを取得しました",
+        description: "10分間この予約をキープします",
+        variant: "default"
+      })
+    }
+
+    if (currentStep < SIMPLIFIED_WIZARD.length) {
+      setCurrentStep(currentStep + 1)
+    }
+  }
+
+  const handlePrevious = () => {
+    if (currentStep > 1) {
+      setCurrentStep(currentStep - 1)
+    }
+  }
+
+  const checkRoomAvailability = async () => {
+    try {
+      // すべての部屋の空室状況をチェック
+      const allRoomIds = ["R201", "R202", "R203", "R204", "R205", "R301", "R302", "R303", "R304", "R305", "R306", "R307"]
+      const results = await checkAvailability(allRoomIds, formData.dateRange)
+      setAvailabilityResults(results)
+    } catch (error) {
+      console.error("空室チェックエラー:", error)
+    }
+  }
+
+  const handleComplete = async () => {
+    if (!validateCurrentStep()) return
+
+    setIsSubmitting(true)
+    try {
+      // 最終検証（排他制御付き）
+      const finalValidationResult = await finalValidation({
+        roomIds: formData.selectedRooms,
+        startDate: formData.dateRange.startDate,
+        endDate: formData.dateRange.endDate,
+        guestCount: Object.values(formData.guests).reduce((sum, count) => sum + count, 0),
+        guestName: formData.guestName
+      })
+
+      if (!finalValidationResult.isValid) {
+        setValidationErrors(finalValidationResult.errors)
+        if (finalValidationResult.conflicts.length > 0) {
+          toast({
+            title: "❌ 予約確定に失敗しました",
+            description: "最終確認で競合が検出されました",
+            variant: "destructive"
+          })
+        }
+        return
+      }
+
+      // 予約データを作成
+      const bookingData = {
+        ...formData,
+        priceBreakdown,
+        status: "confirmed",
+        createdAt: new Date().toISOString(),
+      }
+
+      // 競合状態をリセット
+      resetConflictState()
+
+      toast({
+        title: "✅ 予約が完了しました",
+        description: "確認メールをお送りしました",
+        variant: "default"
+      })
+
+      // 完了コールバック実行
+      if (onComplete) {
+        onComplete(bookingData)
+      } else {
+        // デフォルトの完了処理
+        router.push("/booking")
+      }
+    } catch (error) {
+      console.error("予約完了エラー:", error)
+      setValidationErrors(["予約の作成に失敗しました。もう一度お試しください。"])
+      
+      toast({
+        title: "❌ 予約作成エラー",
+        description: "システムエラーが発生しました。お時間をおいてお試しください",
+        variant: "destructive"
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const updateFormData = (stepData: Partial<SimpleBookingFormData>) => {
+    setFormData((prev) => ({ ...prev, ...stepData }))
+    setValidationErrors([])
+  }
+
+  const renderStepContent = () => {
+    switch (currentStep) {
+      case 1:
+        return (
+          <BasicInfoStep
+            formData={formData}
+            onChange={updateFormData}
+            availabilityResults={availabilityResults}
+          />
+        )
+
+      case 2:
+        return (
+          <RoomAndOptionsStep
+            formData={formData}
+            onChange={updateFormData}
+            availabilityResults={availabilityResults}
+            priceBreakdown={priceBreakdown}
+          />
+        )
+
+      case 3:
+        return (
+          <ConfirmationStep
+            formData={formData}
+            priceBreakdown={priceBreakdown}
+            onChange={updateFormData}
+          />
+        )
+
+      default:
+        return null
+    }
+  }
+
+  const progress = ((currentStep - 1) / (SIMPLIFIED_WIZARD.length - 1)) * 100
+
+  return (
+    <div className="max-w-4xl mx-auto p-6 space-y-6">
+      {/* ステップ進捗 */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle>予約作成 - {SIMPLIFIED_WIZARD[currentStep - 1].title}</CardTitle>
+              <CardDescription>{SIMPLIFIED_WIZARD[currentStep - 1].desc}</CardDescription>
+            </div>
+            <Badge variant="secondary">
+              {currentStep} / {SIMPLIFIED_WIZARD.length}
+            </Badge>
+          </div>
+          <Progress value={progress} className="mt-4" />
+        </CardHeader>
+      </Card>
+
+      {/* エラー表示 */}
+      {validationErrors.length > 0 && (
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>
+            <ul className="list-disc list-inside space-y-1">
+              {validationErrors.map((error, index) => (
+                <li key={index}>{error}</li>
+              ))}
+            </ul>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {/* 競合警告 */}
+      {conflictWarnings.length > 0 && (
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>
+            <div className="space-y-2">
+              <div className="font-semibold">予約競合が検出されました</div>
+              <ul className="list-disc list-inside space-y-1">
+                {conflictWarnings.map((warning, index) => (
+                  <li key={index}>{warning}</li>
+                ))}
+              </ul>
+            </div>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {/* ロック状態とセッション情報 */}
+      {(hasLock || otherActiveSessions > 0) && (
+        <Alert variant={hasLock ? "default" : "destructive"}>
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>
+            <div className="space-y-1">
+              {hasLock && <div>🔐 予約ロック取得済み（他のユーザーによる変更をブロック中）</div>}
+              {isLockExpiring && <div>⏰ ロック期限切れまで1分を切りました</div>}
+              {otherActiveSessions > 0 && (
+                <div>👥 {otherActiveSessions}名のユーザーが同じ期間を検討中です</div>
+              )}
+            </div>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {/* ステップコンテンツ */}
+      <Card>
+        <CardContent className="pt-6">
+          {renderStepContent()}
+        </CardContent>
+      </Card>
+
+      {/* 料金表示 */}
+      {priceBreakdown && currentStep >= 2 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>料金明細</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-3 gap-4 text-sm">
+              <div>
+                <div className="text-muted-foreground">室料</div>
+                <div className="font-semibold">¥{priceBreakdown.roomAmount?.toLocaleString()}</div>
+              </div>
+              <div>
+                <div className="text-muted-foreground">個人料金</div>
+                <div className="font-semibold">¥{priceBreakdown.guestAmount?.toLocaleString()}</div>
+              </div>
+              <div>
+                <div className="text-muted-foreground">オプション</div>
+                <div className="font-semibold">¥{priceBreakdown.addonAmount?.toLocaleString()}</div>
+              </div>
+            </div>
+            <div className="border-t pt-4 mt-4">
+              <div className="flex justify-between items-center text-lg font-bold">
+                <span>合計金額（税込）</span>
+                <span>¥{priceBreakdown.total?.toLocaleString()}</span>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* ナビゲーションボタン */}
+      <div className="flex justify-between">
+        <Button
+          variant="outline"
+          onClick={handlePrevious}
+          disabled={currentStep === 1}
+        >
+          前へ
+        </Button>
+
+        {currentStep < SIMPLIFIED_WIZARD.length ? (
+          <Button onClick={handleNext}>
+            次へ
+          </Button>
+        ) : (
+          <Button 
+            onClick={handleComplete} 
+            disabled={isSubmitting}
+            className="bg-green-600 hover:bg-green-700"
+          >
+            {isSubmitting ? "作成中..." : "予約を確定する"}
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
✨ **Directory Structure Renovation**
- Reorganized admin functionality into logical settings structure
- Created app/(dashboard)/settings/ with organized sections
- Removed admin/ directory completely after migration

✨ **Navigation Simplification**
- Updated main navigation: "管理画面" → "設定"
- Clean 4-section design: ダッシュボード → 予約管理 → カレンダー → 設定
- Settings page organizes all admin functions into logical categories

✨ **Booking Flow Simplification**
- Created simplified 3-step booking wizard (reduced from 5 steps)
- BasicInfoStep: Combined date/people/contact information
- RoomAndOptionsStep: Integrated room selection with options
- ConfirmationStep: Streamlined final confirmation

Resolves #58

🚀 Generated with [Claude Code](https://claude.ai/code)