### PR TITLE
fix: toLocaleString null safety checks for booking components

### DIFF
--- a/components/booking/simple/ConfirmationStep.tsx
+++ b/components/booking/simple/ConfirmationStep.tsx
@@ -171,7 +171,7 @@ export function ConfirmationStep({ formData, priceBreakdown, onChange }: Confirm
                   <Badge variant="secondary">{getRoomTypeLabel(room.type)}</Badge>
                 </div>
                 <div className="text-right">
-                  <div className="font-medium">¥{room.basePrice.toLocaleString()}</div>
+                  <div className="font-medium">¥{(room.basePrice || 0).toLocaleString()}</div>
                   <div className="text-sm text-muted-foreground">定員{room.capacity}名</div>
                 </div>
               </div>
@@ -209,10 +209,10 @@ export function ConfirmationStep({ formData, priceBreakdown, onChange }: Confirm
                     </div>
                     <div className="text-right">
                       <div className="font-medium">
-                        ¥{(optionData.price * addon.quantity).toLocaleString()}
+                        ¥{((optionData.price || 0) * (addon.quantity || 1)).toLocaleString()}
                       </div>
                       <div className="text-sm text-muted-foreground">
-                        ¥{optionData.price.toLocaleString()} × {addon.quantity}
+                        ¥{(optionData.price || 0).toLocaleString()} × {addon.quantity || 1}
                       </div>
                     </div>
                   </div>
@@ -233,20 +233,20 @@ export function ConfirmationStep({ formData, priceBreakdown, onChange }: Confirm
             <div className="space-y-3">
               <div className="flex justify-between">
                 <span>室料</span>
-                <span>¥{priceBreakdown.roomAmount?.toLocaleString()}</span>
+                <span>¥{(priceBreakdown.roomAmount || 0).toLocaleString()}</span>
               </div>
               <div className="flex justify-between">
                 <span>個人料金</span>
-                <span>¥{priceBreakdown.guestAmount?.toLocaleString()}</span>
+                <span>¥{(priceBreakdown.guestAmount || 0).toLocaleString()}</span>
               </div>
               <div className="flex justify-between">
                 <span>オプション</span>
-                <span>¥{priceBreakdown.addonAmount?.toLocaleString()}</span>
+                <span>¥{(priceBreakdown.addonAmount || 0).toLocaleString()}</span>
               </div>
               <Separator />
               <div className="flex justify-between text-lg font-bold">
                 <span>合計金額（税込）</span>
-                <span>¥{priceBreakdown.total?.toLocaleString()}</span>
+                <span>¥{(priceBreakdown.total || 0).toLocaleString()}</span>
               </div>
             </div>
           </CardContent>

--- a/components/booking/simple/RoomAndOptionsStep.tsx
+++ b/components/booking/simple/RoomAndOptionsStep.tsx
@@ -271,7 +271,7 @@ export function RoomAndOptionsStep({ formData, onChange, availabilityResults, pr
                       </div>
                       <div className="flex items-center justify-between">
                         <span>基本料金</span>
-                        <span>¥{room.roomRate.toLocaleString()}</span>
+                        <span>¥{(room.roomRate || 0).toLocaleString()}</span>
                       </div>
                       <div className="flex items-center justify-between">
                         <span>状態</span>

--- a/components/booking/simple/SimpleBookingWizard.tsx
+++ b/components/booking/simple/SimpleBookingWizard.tsx
@@ -481,21 +481,21 @@ export function SimpleBookingWizard({ onComplete, initialData }: SimpleBookingWi
             <div className="grid grid-cols-3 gap-4 text-sm">
               <div>
                 <div className="text-muted-foreground">室料</div>
-                <div className="font-semibold">¥{priceBreakdown.roomAmount?.toLocaleString()}</div>
+                <div className="font-semibold">¥{(priceBreakdown.roomAmount || 0).toLocaleString()}</div>
               </div>
               <div>
                 <div className="text-muted-foreground">個人料金</div>
-                <div className="font-semibold">¥{priceBreakdown.guestAmount?.toLocaleString()}</div>
+                <div className="font-semibold">¥{(priceBreakdown.guestAmount || 0).toLocaleString()}</div>
               </div>
               <div>
                 <div className="text-muted-foreground">オプション</div>
-                <div className="font-semibold">¥{priceBreakdown.addonAmount?.toLocaleString()}</div>
+                <div className="font-semibold">¥{(priceBreakdown.addonAmount || 0).toLocaleString()}</div>
               </div>
             </div>
             <div className="border-t pt-4 mt-4">
               <div className="flex justify-between items-center text-lg font-bold">
                 <span>合計金額（税込）</span>
-                <span>¥{priceBreakdown.total?.toLocaleString()}</span>
+                <span>¥{(priceBreakdown.total || 0).toLocaleString()}</span>
               </div>
             </div>
           </CardContent>


### PR DESCRIPTION
This PR fixes the remaining toLocaleString TypeError issues in the booking system.

## Issues Fixed

- Fixed room.roomRate.toLocaleString() in RoomAndOptionsStep.tsx
- Fixed priceBreakdown properties in SimpleBookingWizard.tsx
- Fixed price displays in ConfirmationStep.tsx
- All toLocaleString() calls now have (value || 0) null safety

## Expected Results
- ✅ No more JavaScript TypeError on /booking/new page
- ✅ Stable price calculation and display
- ✅ Complete booking wizard functionality

Closes #75

Generated with [Claude Code](https://claude.ai/code)