### PR TITLE
fix: resolve toLocaleString undefined error on booking/new page

### DIFF
--- a/components/booking/booking-confirmation.tsx
+++ b/components/booking/booking-confirmation.tsx
@@ -145,7 +145,7 @@ export function BookingConfirmation({
                         (定員{room?.capacity}名)
                       </span>
                     </div>
-                    <span className="text-sm">¥{room?.rate.toLocaleString()}/泊</span>
+                    <span className="text-sm">¥{(room?.rate || 0).toLocaleString()}/泊</span>
                   </div>
                 ))}
               </div>
@@ -180,19 +180,19 @@ export function BookingConfirmation({
               <CardContent className="space-y-3">
                 <div className="flex justify-between">
                   <span className="text-sm text-muted-foreground">室料</span>
-                  <span>¥{priceBreakdown.roomAmount?.toLocaleString()}</span>
+                  <span>¥{(priceBreakdown.roomAmount || 0).toLocaleString()}</span>
                 </div>
                 <div className="flex justify-between">
                   <span className="text-sm text-muted-foreground">個人料金</span>
-                  <span>¥{priceBreakdown.guestAmount?.toLocaleString()}</span>
+                  <span>¥{(priceBreakdown.guestAmount || 0).toLocaleString()}</span>
                 </div>
                 <div className="flex justify-between">
                   <span className="text-sm text-muted-foreground">オプション</span>
-                  <span>¥{priceBreakdown.addonAmount?.toLocaleString()}</span>
+                  <span>¥{(priceBreakdown.addonAmount || 0).toLocaleString()}</span>
                 </div>
                 <div className="border-t pt-3 flex justify-between items-center text-lg font-bold">
                   <span>合計金額（税込）</span>
-                  <span className="text-green-600">¥{priceBreakdown.total?.toLocaleString()}</span>
+                  <span className="text-green-600">¥{(priceBreakdown.total || 0).toLocaleString()}</span>
                 </div>
               </CardContent>
             </Card>

--- a/components/booking/booking-wizard.tsx
+++ b/components/booking/booking-wizard.tsx
@@ -553,21 +553,21 @@ export function BookingWizard({ onComplete, initialData }: BookingWizardProps) {
             <div className="grid grid-cols-3 gap-4 text-sm">
               <div>
                 <div className="text-muted-foreground">室料</div>
-                <div className="font-semibold">¥{priceBreakdown.roomAmount?.toLocaleString()}</div>
+                <div className="font-semibold">¥{(priceBreakdown.roomAmount || 0).toLocaleString()}</div>
               </div>
               <div>
                 <div className="text-muted-foreground">個人料金</div>
-                <div className="font-semibold">¥{priceBreakdown.guestAmount?.toLocaleString()}</div>
+                <div className="font-semibold">¥{(priceBreakdown.guestAmount || 0).toLocaleString()}</div>
               </div>
               <div>
                 <div className="text-muted-foreground">オプション</div>
-                <div className="font-semibold">¥{priceBreakdown.addonAmount?.toLocaleString()}</div>
+                <div className="font-semibold">¥{(priceBreakdown.addonAmount || 0).toLocaleString()}</div>
               </div>
             </div>
             <div className="border-t pt-4 mt-4">
               <div className="flex justify-between items-center text-lg font-bold">
                 <span>合計金額（税込）</span>
-                <span>¥{priceBreakdown.total?.toLocaleString()}</span>
+                <span>¥{(priceBreakdown.total || 0).toLocaleString()}</span>
               </div>
             </div>
           </CardContent>

--- a/components/booking/room-search.tsx
+++ b/components/booking/room-search.tsx
@@ -842,7 +842,7 @@ export function RoomSearch({ onRoomSelect, onSearchResults, initialData }: RoomS
                         )}
                       </div>
                       <div className="text-right">
-                        <div className="font-semibold">¥{room.pricePerNight.toLocaleString()}/泊</div>
+                        <div className="font-semibold">¥{(room.pricePerNight || 0).toLocaleString()}/泊</div>
                         <Badge 
                           variant={room.availability === "available" ? "success" : "destructive"}
                           className="mt-1"
@@ -899,7 +899,7 @@ export function RoomSearch({ onRoomSelect, onSearchResults, initialData }: RoomS
                           
                           {suggestion.estimatedSavings && (
                             <div className="text-sm text-green-600">
-                              推定節約額: ¥{suggestion.estimatedSavings.toLocaleString()}
+                              推定節約額: ¥{(suggestion.estimatedSavings || 0).toLocaleString()}
                             </div>
                           )}
                           

--- a/components/booking/simple/RoomAndOptionsStep.tsx
+++ b/components/booking/simple/RoomAndOptionsStep.tsx
@@ -341,7 +341,7 @@ export function RoomAndOptionsStep({ formData, onChange, availabilityResults, pr
                                 {option.description}
                               </p>
                               <div className="text-sm font-medium mt-2">
-                                ¥{option.price.toLocaleString()} / {option.unit}
+                                ¥{(option.price || 0).toLocaleString()} / {option.unit}
                               </div>
                             </div>
                           </div>


### PR DESCRIPTION
Fixes #85

Resolves the JavaScript error "Cannot read properties of undefined (reading 'toLocaleString')" that occurred when clicking "次へ" on the booking/new page.

**Changes:**
- Added fallback values (|| 0) for all toLocaleString() calls in booking components
- Fixed RoomAndOptionsStep.tsx, room-search.tsx, booking-wizard.tsx, and booking-confirmation.tsx
- Changed from optional chaining without fallbacks to safe fallback pattern

**Root Cause:** Price data was sometimes null/undefined during initial load or calculation, causing toLocaleString() to throw an error.

Generated with [Claude Code](https://claude.ai/code)