### PR TITLE
feat: redirect to booking list page after completion

### DIFF
--- a/app/(dashboard)/booking/new/page.tsx
+++ b/app/(dashboard)/booking/new/page.tsx
@@ -95,8 +95,8 @@ export default function NewBookingPage() {
         if (roomError) throw roomError
       }
 
-      // 予約詳細ページにリダイレクト
-      router.push(`/booking/${project.id}`)
+      // 予約一覧ページにリダイレクト
+      router.push("/booking")
     } catch (error) {
       console.error("予約保存エラー:", error)
       // エラーハンドリング（トースト通知など）


### PR DESCRIPTION
Fixes #93

## Summary
- Changed booking completion redirect from booking details to booking list
- Users now see all bookings after creating a new booking
- Improves workflow for multiple booking creation

## Changes
- `app/(dashboard)/booking/new/page.tsx`: Updated redirect destination

## Test Plan
- Navigate to /booking/new
- Complete booking wizard
- Click "予約を確定する" button
- Verify redirect to /booking (booking list)

Generated with [Claude Code](https://claude.ai/code)