### PR TITLE
fix: Use pre-calculated addon totalPrice for accurate pricing

### DIFF
--- a/lib/pricing/calculator.ts
+++ b/lib/pricing/calculator.ts
@@ -382,21 +382,41 @@ export class PriceCalculator {
     addons.forEach((addon, index) => {
       console.log(`🧮 [PriceCalculator] Processing addon ${index + 1}:`, addon)
       
-      const rate = this.getAddonRate(addon.category, addon.addonId)
-      const quantity = addon.quantity || 1
-      
-      console.log('🧮 [PriceCalculator] Rate retrieved:', rate, 'Quantity:', quantity)
-      
-      // Daily addons multiply by nights, one-time addons don't
-      const isDailyAddon = ['breakfast', 'lunch', 'dinner', 'meal_breakfast', 'meal_lunch', 'meal_dinner'].includes(addon.addonId)
-      const multiplier = isDailyAddon ? dateRange.nights : 1
-      
-      console.log('🧮 [PriceCalculator] Is daily addon:', isDailyAddon, 'Multiplier:', multiplier)
-      
-      const addonTotal = rate * quantity * multiplier
-      console.log('🧮 [PriceCalculator] Addon total:', addonTotal, '=', rate, '*', quantity, '*', multiplier)
-      
-      total += addonTotal
+      // Use the totalPrice already calculated in the addon object if available
+      // This includes the correct pricing from the database
+      if (addon.totalPrice !== undefined) {
+        console.log('🧮 [PriceCalculator] Using pre-calculated totalPrice:', addon.totalPrice)
+        
+        // For daily addons (meals), multiply by nights
+        const isDailyAddon = ['breakfast', 'lunch', 'dinner', 'meal_breakfast', 'meal_lunch', 'meal_dinner'].includes(addon.addonId)
+        const multiplier = isDailyAddon ? dateRange.nights : 1
+        
+        console.log('🧮 [PriceCalculator] Is daily addon:', isDailyAddon, 'Multiplier:', multiplier)
+        
+        const addonTotal = addon.totalPrice * multiplier
+        console.log('🧮 [PriceCalculator] Addon total:', addonTotal, '= totalPrice(', addon.totalPrice, ') * multiplier(', multiplier, ')')
+        
+        total += addonTotal
+      } else {
+        // Fallback to old calculation method for backward compatibility
+        console.log('🧮 [PriceCalculator] No totalPrice found, using fallback calculation')
+        
+        const rate = this.getAddonRate(addon.category, addon.addonId)
+        const quantity = addon.quantity || 1
+        
+        console.log('🧮 [PriceCalculator] Rate retrieved:', rate, 'Quantity:', quantity)
+        
+        // Daily addons multiply by nights, one-time addons don't
+        const isDailyAddon = ['breakfast', 'lunch', 'dinner', 'meal_breakfast', 'meal_lunch', 'meal_dinner'].includes(addon.addonId)
+        const multiplier = isDailyAddon ? dateRange.nights : 1
+        
+        console.log('🧮 [PriceCalculator] Is daily addon:', isDailyAddon, 'Multiplier:', multiplier)
+        
+        const addonTotal = rate * quantity * multiplier
+        console.log('🧮 [PriceCalculator] Addon total:', addonTotal, '=', rate, '*', quantity, '*', multiplier)
+        
+        total += addonTotal
+      }
     })
 
     console.log('🧮 [PriceCalculator] Final addon total:', total)


### PR DESCRIPTION
Fixes #113

## Problem
Facilities and equipment options were not being reflected in the price calculation, showing ¥0 in the options total even when selected with quantities.

## Root Cause
The `calculateAddonPriceSimplified()` function was trying to map database addon IDs to hardcoded rate tables, but the actual IDs like "meeting_room_weekday", "gymnasium_weekday" didn't match the hardcoded keys.

## Solution
- Modified pricing calculation to use the `totalPrice` already stored in addon objects
- The `RoomAndOptionsStep` component already fetches correct pricing from database
- Maintains backward compatibility with fallback to old calculation method
- Ensures all option types (meals, facilities, equipment) are properly priced

## Changes
- `lib/pricing/calculator.ts`: Enhanced `calculateAddonPriceSimplified()` to use pre-calculated `totalPrice`
- Added proper logging for debugging addon pricing calculations
- Fixed facilities and equipment pricing discrepancies

Generated with [Claude Code](https://claude.ai/code)