### PR TITLE
fix: remove email references from booking completion toasts

### DIFF
--- a/components/booking/booking-wizard.tsx
+++ b/components/booking/booking-wizard.tsx
@@ -384,7 +384,7 @@ export function BookingWizard({ onComplete, initialData }: BookingWizardProps) {
 
       toast({
         title: "✅ 予約が完了しました",
-        description: "確認メールをお送りしました",
+        description: "予約内容を確認してください",
         variant: "default"
       })
 

--- a/components/booking/simple/SimpleBookingWizard.tsx
+++ b/components/booking/simple/SimpleBookingWizard.tsx
@@ -446,7 +446,7 @@ export function SimpleBookingWizard({ onComplete, initialData }: SimpleBookingWi
 
       toast({
         title: "✅ 予約が完了しました",
-        description: `予約ID: ${createdBooking.id} - 確認メールをお送りしました`,
+        description: `予約ID: ${createdBooking.id}`,
         variant: "default"
       })
 


### PR DESCRIPTION
Fixes #132

## Summary
- Removed misleading "confirmation email sent" messages from toast notifications
- SimpleBookingWizard: Show only booking ID without email reference
- BookingWizard: Changed to "Please confirm booking details" message

Since emails are not actually sent, these messages were creating false user expectations. Toast notifications now accurately reflect system capabilities.

Generated with [Claude Code](https://claude.ai/code)